### PR TITLE
adding additional party identifier types from mojaloop api spec

### DIFF
--- a/src/outboundApi/api.yaml
+++ b/src/outboundApi/api.yaml
@@ -281,6 +281,12 @@ components:
       enum:
       - MSISDN
       - ACCOUNT_ID
+      - EMAIL
+      - PERSONAL_ID
+      - BUSINESS
+      - DEVICE
+      - IBAN
+      - ALIAS
       description: Below are the allowed values for the enumeration.
       
         - MSISDN -  An MSISDN (Mobile Station International Subscriber Directory Number, that is, the phone number) is used as reference to a participant. The MSISDN identifier should be in international format according to the [ITU-T E.164 standard](https://www.itu.int/rec/T-REC-E.164/en). Optionally, the MSISDN may be prefixed by a single plus sign, indicating the international prefix.


### PR DESCRIPTION
adding additional party identifier types from mojaloop api spec to allow testing of oracle developments