### PR TITLE
Add git to docker image to allow npm install of oauth server component

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:8.11.3-alpine
 
+RUN apk add --no-cache git
+
 EXPOSE 3000
 
 COPY ./secrets /


### PR DESCRIPTION
koa2-oauth-server module apparently needs git binary to npm install.