### PR TITLE
MP-626 pass outbound model mojaloop errors back to caller

### DIFF
--- a/docs/dfspInboundApi.yaml
+++ b/docs/dfspInboundApi.yaml
@@ -290,6 +290,8 @@ components:
 
     errorResponse:
       type: object
+      required:
+        - statusCode
       properties:
         statusCode:
           type: string

--- a/src/lib/model/lib/requests/common.js
+++ b/src/lib/model/lib/requests/common.js
@@ -54,7 +54,7 @@ const throwOrJson = async (res) => {
     // TODO: will a 503 or 500 with content-length zero generate an error?
     // or a 404 for that matter?!
 
-    if (res.headers['content-length'] === '0' || res.status === 204 || res.status === 404) {
+    if (res.headers['content-length'] === '0' || res.status === 204) {
         // success but no content, return null
         return null;
     }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "8.1.8",
+  "version": "8.4.0",
   "description": "An adapter for connecting to Mojaloop API enabled switches",
   "main": "index.js",
   "scripts": {

--- a/src/test/__mocks__/@internal/cache.js
+++ b/src/test/__mocks__/@internal/cache.js
@@ -39,6 +39,13 @@ class MockClient extends EventEmitter {
             this.emit('message', 'channel', data);
         });
     }
+
+    quit(...args) {
+        console.log(`MockClient quit called with args: ${util.inspect(args)}`);
+        if(typeof(args[0]) === 'function') {
+            args[0]();
+        }
+    }
 }
 
 

--- a/src/test/unit/inboundApi/handlers.test.js
+++ b/src/test/unit/inboundApi/handlers.test.js
@@ -15,7 +15,7 @@ jest.mock('@internal/model').inboundTransfersModel;
 const handlers = require('../../../inboundApi/handlers');
 const Model = require('@internal/model').inboundTransfersModel;
 
-describe('handlers:', () => {
+describe('Inbound API handlers:', () => {
     let mockArguments;
 
     beforeEach(() => {
@@ -49,7 +49,7 @@ describe('handlers:', () => {
         };
     });
 
-    describe('POST /quotes:', () => {
+    describe('POST /quotes', () => {
         let mockContext;
 
         beforeEach(() => {

--- a/src/test/unit/lib/model/outboundModel.test.js
+++ b/src/test/unit/lib/model/outboundModel.test.js
@@ -700,4 +700,164 @@ describe('outboundModel', () => {
             }
         })
     );
+
+    test('Throws with mojaloop error in response body when party resolution error callback occurs', async () => {
+        config.AUTO_ACCEPT_PARTY = 'true';
+        config.AUTO_ACCEPT_QUOTES = 'true';
+
+        await setConfig(config);
+        const conf = getConfig();
+
+        const model = new Model({
+            cache: new MockCache(),
+            logger: new Logger({ context: { app: 'outbound-model-unit-tests' }, space:4, transports:logTransports }),
+            ...conf
+        });
+
+        await model.initialize(JSON.parse(JSON.stringify(transferRequest)));
+
+        expect(model.stateMachine.state).toBe('start');
+
+        const expectError = {
+            errorInformation: {
+                errorCode: '3204',
+                errorDescription: 'Party not found'
+            }
+        };
+
+        model.requests.on('getParties', () => {
+            // simulate a callback with a mojaloop error
+            model.cache.emitMessage(JSON.stringify(expectError));
+        });
+
+        const errMsg = 'Got an error response resolving party: { errorInformation: { errorCode: \'3204\', errorDescription: \'Party not found\' } }';
+
+        try {
+            await model.run();
+        }
+        catch(err) {
+            expect(err.message).toEqual(errMsg);
+            expect(err.transferState).toBeTruthy();
+            expect(err.transferState.lastError).toBeTruthy();
+            expect(err.transferState.lastError.mojaloopError).toEqual(expectError);
+            return;
+        }
+
+        throw new Error('Outbound model should have thrown');
+    });
+
+
+    test('Throws with mojaloop error in response body when quote request error callback occurs', async () => {
+        config.AUTO_ACCEPT_PARTY = 'true';
+        config.AUTO_ACCEPT_QUOTES = 'true';
+
+        await setConfig(config);
+        const conf = getConfig();
+
+        const model = new Model({
+            cache: new MockCache(),
+            logger: new Logger({ context: { app: 'outbound-model-unit-tests' }, space:4, transports:logTransports }),
+            ...conf
+        });
+
+        await model.initialize(JSON.parse(JSON.stringify(transferRequest)));
+
+        expect(model.stateMachine.state).toBe('start');
+
+        const expectError = {
+            type: 'quoteResponseError',
+            data: {
+                errorInformation: {
+                    errorCode: '3205',
+                    errorDescription: 'Quote ID not found'
+                }
+            }
+        };
+
+        model.requests.on('getParties', () => {
+            // simulate a callback with the resolved party
+            model.cache.emitMessage(JSON.stringify(payeeParty));
+        });
+
+        model.requests.on('postQuotes', () => {
+            // simulate an error callback
+            model.cache.emitMessage(JSON.stringify(expectError));
+        });
+
+        const errMsg = 'Got an error response requesting quote: { type: \'quoteResponseError\',\n  data:\n   { errorInformation:\n      { errorCode: \'3205\', errorDescription: \'Quote ID not found\' } } }';
+
+        try {
+            await model.run();
+        }
+        catch(err) {
+            expect(err.message).toEqual(errMsg);
+            expect(err.transferState).toBeTruthy();
+            expect(err.transferState.lastError).toBeTruthy();
+            expect(err.transferState.lastError.mojaloopError).toEqual(expectError.data);
+            return;
+        }
+
+        throw new Error('Outbound model should have thrown');
+    });
+
+
+    test('Throws with mojaloop error in response body when transfer request error callback occurs', async () => {
+        config.AUTO_ACCEPT_PARTY = 'true';
+        config.AUTO_ACCEPT_QUOTES = 'true';
+
+        await setConfig(config);
+        const conf = getConfig();
+
+        const model = new Model({
+            cache: new MockCache(),
+            logger: new Logger({ context: { app: 'outbound-model-unit-tests' }, space:4, transports:logTransports }),
+            ...conf
+        });
+
+        await model.initialize(JSON.parse(JSON.stringify(transferRequest)));
+
+        expect(model.stateMachine.state).toBe('start');
+
+        const expectError = {
+            type: 'transferError',
+            data: {
+                errorInformation: {
+                    errorCode: '4001',
+                    errorDescription: 'Payer FSP insufficient liquidity'
+                }
+            }
+        };
+
+        model.requests.on('getParties', () => {
+            // simulate a callback with the resolved party
+            model.cache.emitMessage(JSON.stringify(payeeParty));
+        });
+
+        model.requests.on('postQuotes', () => {
+            // simulate a callback with the quote response
+            model.cache.emitMessage(JSON.stringify(quoteResponse));
+        });
+
+        model.requests.on('postTransfers', () => {
+            // simulate an error callback with the transfer fulfilment
+            model.cache.emitMessage(JSON.stringify(expectError));
+        });
+
+
+        const errMsg = 'Got an error response preparing transfer: { type: \'transferError\',\n  data:\n   { errorInformation:\n      { errorCode: \'4001\',\n        errorDescription: \'Payer FSP insufficient liquidity\' } } }';
+
+        try {
+            await model.run();
+        }
+        catch(err) {
+            expect(err.message).toEqual(errMsg);
+            expect(err.transferState).toBeTruthy();
+            expect(err.transferState.lastError).toBeTruthy();
+            expect(err.transferState.lastError.mojaloopError).toEqual(expectError.data);
+            return;
+        }
+
+        throw new Error('Outbound model should have thrown');
+    });
+
 });

--- a/src/test/unit/outboundApi/handlers.test.js
+++ b/src/test/unit/outboundApi/handlers.test.js
@@ -1,0 +1,155 @@
+/**************************************************************************
+ *  (C) Copyright ModusBox Inc. 2019 - All rights reserved.               *
+ *                                                                        *
+ *  This file is made available under the terms of the license agreement  *
+ *  specified in the corresponding source code repository.                *
+ *                                                                        *
+ *  ORIGINAL AUTHOR:                                                      *
+ *       James Bush - james.bush@modusbox.com                             *
+ **************************************************************************/
+
+'use strict';
+
+jest.mock('@internal/model');
+
+const handlers = require('../../../outboundApi/handlers');
+const Model = require('@internal/model'); //.outboundTransfersModel;
+
+
+const transferRequest = {
+    from: {
+        displayName: 'James Bush',
+        idType: 'MSISDN',
+        idValue: '447710066017'
+    },
+    to: {
+        idType: 'MSISDN',
+        idValue: '1234567890'
+    },
+    amountType: 'SEND',
+    currency: 'USD',
+    amount: '100',
+    transactionType: 'TRANSFER',
+    note: 'test payment',
+    homeTransactionId: '123ABC'
+};
+
+const mockError = {
+    message: 'Mock error',
+    httpStatusCode: 500,
+    transferState:  {
+        'from': {
+            'displayName': 'James Bush',
+            'idType': 'MSISDN',
+            'idValue': '447710066017'
+        },
+        'to': {
+            'idType': 'MSISDN',
+            'idValue': '1234567890'
+        },
+        'amountType': 'SEND',
+        'currency': 'USD',
+        'amount': '100',
+        'transactionType': 'TRANSFER',
+        'note': 'test payment',
+        'homeTransactionId': '123ABC',
+        'transferId': '5a2ad5dc-4ab1-4a22-8c5b-62f75252a8d5',
+        'currentState': 'ERROR_OCCURED',
+        'lastError': {
+            'httpStatusCode': 500,
+            'mojaloopError': {
+                'errorInformation': {
+                    'errorCode': '3204',
+                    'errorDescription': 'Party not found'
+                }
+            }
+        }
+    }
+};
+
+
+/**
+ * Mock the outbound transfer model to simulate throwing errors 
+ */
+Model.outboundTransfersModel.mockImplementation(() => {
+    return {
+        run: async () => {
+            // throw the mockError object when the model is run
+            throw mockError;
+        },
+        initialize: async () => {
+            // nothing needed here
+            return;
+        },
+        load: async () => {
+            // nothing needed here
+            return;
+        }
+    };
+});
+
+
+describe('Outbound API handlers:', () => {
+    describe('POST /transfers', () => {
+        test('returns correct error response body when model throws mojaloop error', async () => {
+            const mockContext = {
+                request: {
+                    body: transferRequest,
+                    headers: {
+                        'fspiop-source': 'foo'
+                    }
+                },
+                response: {},
+                state: {
+                    conf: {},
+                    logger: console
+                }
+            };
+
+            await handlers.map['/transfers'].post(mockContext);
+
+            // check response is correct
+            expect(mockContext.response.status).toEqual(500);
+            expect(mockContext.response.body).toBeTruthy();
+            expect(mockContext.response.body.message).toEqual('Mock error');
+            expect(mockContext.response.body.statusCode).toEqual('3204');
+            expect(mockContext.response.body.transferState).toEqual(mockError.transferState);
+        });
+    });
+
+
+    describe('PUT /transfers', () => {
+        test('returns correct error response body when model throws mojaloop error', async () => {
+            const mockContext = {
+                request: {
+                    body: {
+                        acceptQuote: true
+                    },
+                    headers: {
+                        'fspiop-source': 'foo'
+                    }
+                },
+                response: {},
+                state: {
+                    conf: {},
+                    logger: console,
+                    path: {
+                        params: {
+                            transferId: '12345'
+                        }
+                    }
+                }
+            };
+
+            await handlers.map['/transfers/{transferId}'].put(mockContext);
+
+            // check response is correct
+            expect(mockContext.response.status).toEqual(500);
+            expect(mockContext.response.body).toBeTruthy();
+            expect(mockContext.response.body.message).toEqual('Mock error');
+            expect(mockContext.response.body.statusCode).toEqual('3204');
+            expect(mockContext.response.body.transferState).toEqual(mockError.transferState);
+        });
+    });
+
+});


### PR DESCRIPTION
If mojaloop errors are returned from the peer during synchronous outbound transfers the mojaloop error body should be included in the synchronous backend error response.