### PR TITLE
MP-805: use latest sdk standard components version

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {
@@ -25,7 +25,7 @@
     "@internal/router": "file:lib/router",
     "@internal/shared": "file:lib/model/lib/shared",
     "@internal/validate": "file:lib/validate",
-    "@mojaloop/sdk-standard-components": "^8.4.2",
+    "@mojaloop/sdk-standard-components": "^8.6.2",
     "co-body": "^6.0.0",
     "dotenv": "^6.2.0",
     "js-yaml": "^3.13.1",


### PR DESCRIPTION
Use latest sdk standard components version to get token refresh TLS credentials update.