### PR TITLE
fix missing await

### DIFF
--- a/src/lib/model/AccountsModel.js
+++ b/src/lib/model/AccountsModel.js
@@ -133,7 +133,7 @@ class AccountsModel {
         return new Promise(async (resolve, reject) => {
             const requestKey = `ac_${request.requestId}`;
 
-            const subId = this.cache.subscribe(requestKey, async (cn, msg, subId) => {
+            const subId = await this.cache.subscribe(requestKey, async (cn, msg, subId) => {
                 try {
                     let error;
                     let message = JSON.parse(msg);

--- a/src/lib/model/OutboundTransfersModel.js
+++ b/src/lib/model/OutboundTransfersModel.js
@@ -431,7 +431,7 @@ class OutboundTransfersModel {
             // listen for events on the transferId
             const transferKey = `tf_${this.data.transferId}`;
 
-            const subId = this.cache.subscribe(transferKey, async (cn, msg, subId) => {
+            const subId = await this.cache.subscribe(transferKey, async (cn, msg, subId) => {
                 try {
                     let error;
                     let message = JSON.parse(msg);


### PR DESCRIPTION
Missing await when making cache subscription can cause call to unsubscribe before subscribe has completed.