### PR TITLE
MP-1261 error extensionList as source of error body statusCode property

### DIFF
--- a/src/OutboundServer/handlers.js
+++ b/src/OutboundServer/handlers.js
@@ -35,18 +35,17 @@ const handleError = (method, err, ctx, stateField) => {
         // by default we set the statusCode property of the error body to be that of any model state lastError
         // property containing a mojaloop API error structure. This means the caller does not have to inspect
         // the structure of the response object in depth to ascertain an underlying mojaloop API error code.
-        ctx.response.body.statusCode = err[stateField].lastError.mojaloopError.errorInformation.errorCode;
+        const errorInformation = err[stateField].lastError.mojaloopError.errorInformation;
+        ctx.response.body.statusCode = errorInformation.errorCode;
 
         // if we have been configured to use an error extensionList item as status code, look for it and use
         // it if it is present...
         if(ctx.state.conf.outboundErrorStatusCodeExtensionKey
-            && err[stateField].lastError.mojaloopError.errorInformation.extensionList
-            && Array.isArray(err[stateField].lastError.mojaloopError.errorInformation.extensionList)) {
+            && Array.isArray(errorInformation.extensionList)) {
 
             // search the extensionList array for a key that matches what we have been configured to look for...
             // the first one will do - spec is a bit loose on duplicate keys...
-            const extensionItem = err[stateField].lastError.mojaloopError.errorInformation
-                .extensionList.find(e => {
+            const extensionItem = errorInformation.extensionList.find(e => {
                     return e.key === ctx.state.conf.outboundErrorStatusCodeExtensionKey;
                 });
 

--- a/src/OutboundServer/handlers.js
+++ b/src/OutboundServer/handlers.js
@@ -16,7 +16,7 @@ const { AccountsModel, OutboundTransfersModel, OutboundRequestToPayModel } = req
 
 
 /**
- * Common error handling logic
+ * Error handling logic shared by outbound API handlers
  */
 const handleError = (method, err, ctx, stateField) => {
     ctx.state.logger.log(`Error handling ${method}: ${util.inspect(err)}`);
@@ -32,7 +32,28 @@ const handleError = (method, err, ctx, stateField) => {
         && err[stateField].lastError.mojaloopError.errorInformation
         && err[stateField].lastError.mojaloopError.errorInformation.errorCode) {
 
+        // by default we set the statusCode property of the error body to be that of any model state lastError
+        // property containing a mojaloop API error structure. This means the caller does not have to inspect
+        // the structure of the response object in depth to ascertain an underlying mojaloop API error code.
         ctx.response.body.statusCode = err[stateField].lastError.mojaloopError.errorInformation.errorCode;
+
+        // if we have been configured to use an error extensionList item as status code, look for it and use
+        // it if it is present...
+        if(ctx.state.conf.outboundErrorStatusCodeExtensionKey
+            && err[stateField].lastError.mojaloopError.errorInformation.extensionList
+            && Array.isArray(err[stateField].lastError.mojaloopError.errorInformation.extensionList)) {
+
+            // search the extensionList array for a key that matches what we have been configured to look for...
+            // the first one will do - spec is a bit loose on duplicate keys...
+            const extensionItem = err[stateField].lastError.mojaloopError.errorInformation
+                .extensionList.find(e => {
+                    return e.key === ctx.state.conf.outboundErrorStatusCodeExtensionKey;
+                });
+
+            if(extensionItem) {
+                ctx.response.body.statusCode = extensionItem.value;
+            }
+        }
     }
 };
 

--- a/src/OutboundServer/handlers.js
+++ b/src/OutboundServer/handlers.js
@@ -46,8 +46,8 @@ const handleError = (method, err, ctx, stateField) => {
             // search the extensionList array for a key that matches what we have been configured to look for...
             // the first one will do - spec is a bit loose on duplicate keys...
             const extensionItem = errorInformation.extensionList.find(e => {
-                    return e.key === ctx.state.conf.outboundErrorStatusCodeExtensionKey;
-                });
+                return e.key === ctx.state.conf.outboundErrorStatusCodeExtensionKey;
+            });
 
             if(extensionItem) {
                 ctx.response.body.statusCode = extensionItem.value;

--- a/src/config.js
+++ b/src/config.js
@@ -102,4 +102,10 @@ module.exports = {
     logIndent: env.get('LOG_INDENT').default('2').asIntPositive(),
 
     allowTransferWithoutQuote: env.get('allowTransferWithoutQuote').default('false').asBool(),
+
+    // for outbound transfers, allows an extensionList item in an error respone to be used instead
+    // of the primary error code when setting the statusCode property on the synchronous response
+    // to the DFSP backend. This is useful if an intermediary such as FXP returns underlying error
+    // codes in error extensionLists.
+    outboundErrorStatusCodeExtensionKey: env.get('OUTBOUND_ERROR_STATUSCODE_EXTENSION_KEY').asString(),
 };

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {

--- a/src/test/unit/config.test.js
+++ b/src/test/unit/config.test.js
@@ -12,6 +12,8 @@ const fs  = require('fs');
 const path = require('path');
 const os = require('os');
 
+const outErrorStatusKey = 'outErrorStatusKey';
+
 jest.mock('dotenv', () => ({
     config: jest.fn(),
 }));
@@ -34,6 +36,19 @@ describe('config', () => {
         fs.rmdirSync(certDir, { recursive: true });
         jest.resetModules();
     });
+
+    it('correctly parses OUTBOUND_ERROR_STATUSCODE_EXTENSION_KEY when set', () => {
+        process.env.OUTBOUND_ERROR_STATUSCODE_EXTENSION_KEY = outErrorStatusKey;
+        const config = require('../../config');
+        expect(config.outboundErrorStatusCodeExtensionKey).toEqual(outErrorStatusKey);
+    });
+
+    it('correctly parses OUTBOUND_ERROR_STATUSCODE_EXTENSION_KEY when NOT set', () => {
+        delete process.env.OUTBOUND_ERROR_STATUSCODE_EXTENSION_KEY;
+        const config = require('../../config');
+        expect(config.outboundErrorStatusCodeExtensionKey).toBeUndefined();
+    });
+
 
     it('return single cert content from IN_SERVER_CERT_PATH', () => {
         const cert = path.join(certDir, 'cert.pem');

--- a/src/test/unit/outboundApi/data/mockError.json
+++ b/src/test/unit/outboundApi/data/mockError.json
@@ -24,7 +24,14 @@
       "mojaloopError": {
         "errorInformation": {
           "errorCode": "3204",
-          "errorDescription": "Party not found"
+          "errorDescription": "Party not found",
+          "extensionList": [{
+            "key": "someKey",
+            "value": "someValue"
+          }, {
+            "key": "extErrorKey",
+            "value": "9999"
+          }]
         }
       }
     }


### PR DESCRIPTION
MP-1261 add config to allow an extensionList item in a mojaloop error callback to be the source of statusCode in synchronous backend error response.