### PR TITLE
Moved "test" API to a different server.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,15 +67,27 @@ defaults_build_docker_login: &defaults_build_docker_login
 
 defaults_build_docker_build: &defaults_build_docker_build
   name: Build Docker $CIRCLE_TAG image
-  command: |
+  command: >
     echo "Building Docker image: $CIRCLE_TAG"
-    docker build -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG .
+
+    docker build
+    --build-arg=BUILD_DATE="$(date -u --iso-8601=seconds)"
+    --build-arg=VERSION="$CIRCLE_TAG"
+    --build-arg=VCS_URL="$CIRCLE_REPOSITORY_URL"
+    --build-arg=VCS_REF="$CIRCLE_SHA1"
+    -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG .
 
 defaults_build_docker_build_release: &defaults_build_docker_build_release
   name: Build Docker $RELEASE_TAG image
   command: |
     echo "Building Docker image: $RELEASE_TAG"
-    docker build -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG .
+
+    docker build
+    --build-arg=BUILD_DATE="$(date -u --iso-8601=seconds)"
+    --build-arg=VERSION="$RELEASE_TAG"
+    --build-arg=VCS_URL="$CIRCLE_REPOSITORY_URL"
+    --build-arg=VCS_REF="$CIRCLE_SHA1"
+    -t $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG .
 
 defaults_build_docker_publish: &defaults_build_docker_publish
   name: Publish Docker image $CIRCLE_TAG & Latest tag to Docker Hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ defaults_build_docker_build: &defaults_build_docker_build
 
 defaults_build_docker_build_release: &defaults_build_docker_build_release
   name: Build Docker $RELEASE_TAG image
-  command: |
+  command: >
     echo "Building Docker image: $RELEASE_TAG"
 
     docker build

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*node_modules*
+*junit.xml*

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,43 @@ EXPOSE 3000
 
 COPY ./secrets /
 
-WORKDIR /src/
+WORKDIR /sim/
 
-COPY ./src/ /src/
-RUN npm install
+# This is super-ugly, but it means we don't have to re-run npm install every time any of the source
+# files change- only when any dependencies change- which is a superior developer experience when
+# relying on docker-compose.
+COPY ./package.json /sim/package.json
+COPY ./src/lib/cache/package.json /sim/src/lib/cache/package.json
+COPY ./src/lib/log/package.json /sim/src/lib/log/package.json
+COPY ./src/lib/model/lib/requests/package.json /sim/src/lib/model/lib/requests/package.json
+COPY ./src/lib/model/lib/shared/package.json /sim/src/lib/model/lib/shared/package.json
+COPY ./src/lib/model/package.json /sim/src/lib/model/package.json
+COPY ./src/lib/randomphrase/package.json /sim/src/lib/randomphrase/package.json
+COPY ./src/lib/router/package.json /sim/src/lib/router/package.json
+COPY ./src/lib/validate/package.json /sim/src/lib/validate/package.json
+RUN npm install --production
 
-FROM node:12.14.0-alpine 
+FROM node:12.14.0-alpine
 
-WORKDIR /src/
+ARG BUILD_DATE
+ARG VCS_URL
+ARG VCS_REF
+ARG VERSION
 
-COPY --from=builder /src/ .
+# See http://label-schema.org/rc1/ for label schema info
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="finance-portal-ui"
+LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.vcs-url=$VCS_URL
+LABEL org.label-schema.vcs-ref=$VCS_REF
+LABEL org.label-schema.url="https://mojaloop.io/"
+LABEL org.label-schema.version=$VERSION
+
+WORKDIR /sim/
+
+COPY --from=builder /sim/ /sim
+COPY ./src ./src
 COPY ./secrets /
 RUN npm prune --production
 
-CMD ["node", "/src/index.js"]
+CMD ["node", "src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ COPY ./src/lib/model/package.json ./lib/model/package.json
 COPY ./src/lib/randomphrase/package.json ./lib/randomphrase/package.json
 COPY ./src/lib/router/package.json ./lib/router/package.json
 COPY ./src/lib/validate/package.json ./lib/validate/package.json
-RUN npm install --production
-RUN npm prune --production
+RUN npm install
 
 FROM node:12.14.0-alpine
 
@@ -40,6 +39,7 @@ LABEL org.label-schema.version=$VERSION
 WORKDIR /sim/
 
 COPY --from=builder /src/ /sim
+RUN npm prune --production
 COPY ./src ./src
 COPY ./secrets /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,23 +4,22 @@ RUN apk add --no-cache git python build-base
 
 EXPOSE 3000
 
-COPY ./secrets /
-
-WORKDIR /sim/
+WORKDIR /src/
 
 # This is super-ugly, but it means we don't have to re-run npm install every time any of the source
 # files change- only when any dependencies change- which is a superior developer experience when
 # relying on docker-compose.
-COPY ./package.json /sim/package.json
-COPY ./src/lib/cache/package.json /sim/src/lib/cache/package.json
-COPY ./src/lib/log/package.json /sim/src/lib/log/package.json
-COPY ./src/lib/model/lib/requests/package.json /sim/src/lib/model/lib/requests/package.json
-COPY ./src/lib/model/lib/shared/package.json /sim/src/lib/model/lib/shared/package.json
-COPY ./src/lib/model/package.json /sim/src/lib/model/package.json
-COPY ./src/lib/randomphrase/package.json /sim/src/lib/randomphrase/package.json
-COPY ./src/lib/router/package.json /sim/src/lib/router/package.json
-COPY ./src/lib/validate/package.json /sim/src/lib/validate/package.json
+COPY ./src/package.json ./package.json
+COPY ./src/lib/cache/package.json ./lib/cache/package.json
+COPY ./src/lib/log/package.json ./lib/log/package.json
+COPY ./src/lib/model/lib/requests/package.json ./lib/model/lib/requests/package.json
+COPY ./src/lib/model/lib/shared/package.json ./lib/model/lib/shared/package.json
+COPY ./src/lib/model/package.json ./lib/model/package.json
+COPY ./src/lib/randomphrase/package.json ./lib/randomphrase/package.json
+COPY ./src/lib/router/package.json ./lib/router/package.json
+COPY ./src/lib/validate/package.json ./lib/validate/package.json
 RUN npm install --production
+RUN npm prune --production
 
 FROM node:12.14.0-alpine
 
@@ -40,9 +39,8 @@ LABEL org.label-schema.version=$VERSION
 
 WORKDIR /sim/
 
-COPY --from=builder /sim/ /sim
+COPY --from=builder /src/ /sim
 COPY ./src ./src
 COPY ./secrets /
-RUN npm prune --production
 
 CMD ["node", "src/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,6 @@ services:
     ports:
       - "4000:4000"
       - "4001:4001"
+      - "4002:4002"
     depends_on:
       - redis

--- a/src/.env.example
+++ b/src/.env.example
@@ -4,10 +4,14 @@ INBOUND_LISTEN_PORT=4000
 # Port number that the outbound (simplified DFSP outbound API) HTTP server will listen on
 OUTBOUND_LISTEN_PORT=4001
 
+# Port number that the test HTTP server will listen on
+TEST_LISTEN_PORT=4002
+
 # Enable mutual TLS authentication. Useful when not running in a secure
 # environment, i.e. when you're running it locally against your own implementation.
 INBOUND_MUTUAL_TLS_ENABLED=false
 OUTBOUND_MUTUAL_TLS_ENABLED=false
+TEST_MUTUAL_TLS_ENABLED=false
 
 # Enable verification or incoming JWS signatures
 # Note that signatures will be required on incoming messages
@@ -37,6 +41,10 @@ IN_SERVER_KEY_PATH=./secrets/serverkey.pem
 OUT_CA_CERT_PATH=./secrets/cacert.pem
 OUT_CLIENT_CERT_PATH=./secrets/servercert.pem
 OUT_CLIENT_KEY_PATH=./secrets/serverkey.pem
+
+TEST_CA_CERT_PATH=./secrets/cacert.pem
+TEST_CLIENT_CERT_PATH=./secrets/servercert.pem
+TEST_CLIENT_KEY_PATH=./secrets/serverkey.pem
 
 # The number of space characters by which to indent pretty-printed logs. If set to zero, log events
 # will each be printed on a single line.

--- a/src/InboundServer/api.yaml
+++ b/src/InboundServer/api.yaml
@@ -2496,39 +2496,6 @@ paths:
           $ref: '#/components/responses/ErrorResponse503'
       requestBody:
         $ref: '#/components/requestBodies/ErrorInformationObject'
-
-  '/requests/{ID}':
-    get:
-      description: Test support method. Allows the caller to see the body of a previous request
-      summary: getRequestsById
-      tags:
-        - test
-      operationId: getRequestsById
-      parameters:
-        - $ref: '#/components/parameters/ID'
-      responses:
-        '200':
-          description: Response
-          content:
-            application/json:
-              schema:
-                type: object
-  '/callbacks/{ID}':
-    get:
-      description: Test support method. Allows the caller to see the body of a previous callback
-      summary: getRequestsById
-      tags:
-        - test
-      operationId: getCallbackById
-      parameters:
-        - $ref: '#/components/parameters/ID'
-      responses:
-        '200':
-          description: Response
-          content:
-            application/json:
-              schema:
-                type: object
 components:
   parameters:
     Accept:

--- a/src/InboundServer/handlers.js
+++ b/src/InboundServer/handlers.js
@@ -12,7 +12,6 @@
 
 const util = require('util');
 const Model = require('@internal/model').InboundTransfersModel;
-const { Errors } = require('@mojaloop/sdk-standard-components');
 
 /**
  * Handles a GET /participants/{idType}/{idValue} request
@@ -533,52 +532,6 @@ const healthCheck = async(ctx) => {
 };
 
 
-/**
- * Handles a GET /requests/{ID} request. This is a test support method that allows the caller
- * to see the body of a previous incoming request.
- */
-const getRequestById = async(ctx) => {
-    if(!ctx.state.conf.enableTestFeatures) {
-        // hide this endpoint if test features are disabled
-        throw new Errors.MojaloopFSPIOPError(null, 'Couldn\'t match path requests', null,
-            Errors.MojaloopApiErrorCodes.UNKNOWN_URI);
-    }
-
-    try {
-        const req = await ctx.state.cache.get(`request_${ctx.state.path.params.ID}`);
-        ctx.response.status = 200;
-        ctx.response.body = req;
-    }
-    catch(err) {
-        ctx.status = 500;
-        ctx.response.body = err;
-    }
-};
-
-
-/**
- * Handles a GET /callbacks/{ID} request. This is a test support method that allows the caller
- * to see the body of a previous incoming callback.
- */
-const getCallbackById = async(ctx) => {
-    if(!ctx.state.conf.enableTestFeatures) {
-        // hide this endpoint if test features are disabled
-        throw new Errors.MojaloopFSPIOPError(null, 'Couldn\'t match path /callbacks', null,
-            Errors.MojaloopApiErrorCodes.UNKNOWN_URI);
-    }
-
-    try {
-        const req = await ctx.state.cache.get(`callback_${ctx.state.path.params.ID}`);
-        ctx.response.status = 200;
-        ctx.response.body = req;
-    }
-    catch(err) {
-        ctx.status = 500;
-        ctx.response.body = err;
-    }
-};
-
-
 module.exports = {
     '/': {
         get: healthCheck
@@ -637,11 +590,5 @@ module.exports = {
     },
     '/transactionRequests/{ID}': {
         put: putTransactionRequestsById
-    },
-    '/requests/{ID}': {
-        get: getRequestById
-    },
-    '/callbacks/{ID}': {
-        get: getCallbackById
     }
 };

--- a/src/TestServer/api.yaml
+++ b/src/TestServer/api.yaml
@@ -9,7 +9,17 @@ info:
   license:
     name: Open API for FSP Interoperability (FSPIOP)
 paths:
-
+  '/':
+    get:
+      description: Health check
+      summary: healthCheck
+      tags:
+        - test
+      operationId: healthCheck
+      responses:
+        '204':
+          description: Response
+          content: null
   '/requests/{ID}':
     get:
       description: Test support method. Allows the caller to see the body of a previous request

--- a/src/TestServer/api.yaml
+++ b/src/TestServer/api.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Open API for FSP Interoperability (FSPIOP)
+  description: >-
+    Based on API Definition.docx updated on 2018-03-13 Version 1.0. Note - The
+    API supports a maximum size of 65536 bytes (64 Kilobytes) in the HTTP
+    header.
+  license:
+    name: Open API for FSP Interoperability (FSPIOP)
+paths:
+
+  '/requests/{ID}':
+    get:
+      description: Test support method. Allows the caller to see the body of a previous request
+      summary: getRequestsById
+      tags:
+        - test
+      operationId: getRequestsById
+      parameters:
+        - $ref: '#/components/parameters/ID'
+      responses:
+        '200':
+          description: Response
+          content:
+            application/json:
+              schema:
+                type: object
+  '/callbacks/{ID}':
+    get:
+      description: Test support method. Allows the caller to see the body of a previous callback
+      summary: getRequestsById
+      tags:
+        - test
+      operationId: getCallbackById
+      parameters:
+        - $ref: '#/components/parameters/ID'
+      responses:
+        '200':
+          description: Response
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  parameters:
+    ID:
+      name: ID
+      in: path
+      required: true
+      schema:
+        type: string

--- a/src/TestServer/handlers.js
+++ b/src/TestServer/handlers.js
@@ -13,7 +13,7 @@
 const { Errors } = require('@mojaloop/sdk-standard-components');
 
 const healthCheck = async(ctx) => {
-    ctx.response.status = 200;
+    ctx.response.status = 204;
     ctx.response.body = '';
 };
 

--- a/src/TestServer/handlers.js
+++ b/src/TestServer/handlers.js
@@ -1,0 +1,65 @@
+/**************************************************************************
+ *  (C) Copyright ModusBox Inc. 2019 - All rights reserved.               *
+ *                                                                        *
+ *  This file is made available under the terms of the license agreement  *
+ *  specified in the corresponding source code repository.                *
+ *                                                                        *
+ *  ORIGINAL AUTHOR:                                                      *
+ *       James Bush - james.bush@modusbox.com                             *
+ **************************************************************************/
+
+'use strict';
+
+const { Errors } = require('@mojaloop/sdk-standard-components');
+
+const healthCheck = async(ctx) => {
+    ctx.response.status = 200;
+    ctx.response.body = '';
+};
+
+
+/**
+ * Handles a GET /requests/{ID} request. This is a test support method that allows the caller
+ * to see the body of a previous incoming request.
+ */
+const getRequestById = async(ctx) => {
+    try {
+        const req = await ctx.state.cache.get(`request_${ctx.state.path.params.ID}`);
+        ctx.response.status = 200;
+        ctx.response.body = req;
+    }
+    catch(err) {
+        ctx.status = 500;
+        ctx.response.body = err;
+    }
+};
+
+
+/**
+ * Handles a GET /callbacks/{ID} request. This is a test support method that allows the caller
+ * to see the body of a previous incoming callback.
+ */
+const getCallbackById = async(ctx) => {
+    try {
+        const req = await ctx.state.cache.get(`callback_${ctx.state.path.params.ID}`);
+        ctx.response.status = 200;
+        ctx.response.body = req;
+    }
+    catch(err) {
+        ctx.status = 500;
+        ctx.response.body = err;
+    }
+};
+
+
+module.exports = {
+    '/': {
+        get: healthCheck
+    },
+    '/requests/{ID}': {
+        get: getRequestById
+    },
+    '/callbacks/{ID}': {
+        get: getCallbackById
+    },
+};

--- a/src/TestServer/handlers.js
+++ b/src/TestServer/handlers.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-const { Errors } = require('@mojaloop/sdk-standard-components');
-
 const healthCheck = async(ctx) => {
     ctx.response.status = 204;
     ctx.response.body = '';

--- a/src/TestServer/index.js
+++ b/src/TestServer/index.js
@@ -1,0 +1,133 @@
+/**************************************************************************
+ *  (C) Copyright ModusBox Inc. 2019 - All rights reserved.               *
+ *                                                                        *
+ *  This file is made available under the terms of the license agreement  *
+ *  specified in the corresponding source code repository.                *
+ *                                                                        *
+ *  ORIGINAL AUTHOR:                                                      *
+ *       James Bush - james.bush@modusbox.com                             *
+ **************************************************************************/
+
+const Koa = require('koa');
+
+const https = require('https');
+const http = require('http');
+const yaml = require('js-yaml');
+const fs = require('fs');
+const path = require('path');
+
+const { WSO2Auth } = require('@mojaloop/sdk-standard-components');
+const { Logger, Transports } = require('@internal/log');
+const Cache = require('@internal/cache');
+
+const Validate = require('@internal/validate');
+const router = require('@internal/router');
+const handlers = require('./handlers');
+const middlewares = require('../InboundServer/middlewares');
+
+class TestServer {
+    constructor(conf) {
+        this._conf = conf;
+        this._api = null;
+        this._server = null;
+        this._logger = null;
+        this._jwsVerificationKeys = {};
+    }
+
+    async setupApi() {
+        this._api = new Koa();
+        this._logger = await this._createLogger();
+
+        this._cache = await this._createCache();
+
+        const specPath = path.join(__dirname, 'api.yaml');
+        const apiSpecs = yaml.load(fs.readFileSync(specPath));
+        const validator = new Validate();
+        await validator.initialise(apiSpecs);
+
+        this._wso2Auth = new WSO2Auth({
+            ...this._conf.wso2Auth,
+            logger: this._logger,
+            tlsCreds: this._conf.tls.test.mutualTLS.enabled && this._conf.tls.test.creds,
+        });
+
+        this._api.use(middlewares.createErrorHandler());
+        this._api.use(middlewares.createRequestIdGenerator());
+        const sharedState = { cache: this._cache, wso2Auth: this._wso2Auth, conf: this._conf };
+        this._api.use(middlewares.createLogger(this._logger, sharedState));
+
+        this._api.use(middlewares.createRequestValidator(validator));
+        this._api.use(router(handlers));
+        this._api.use(middlewares.createResponseBodyHandler());
+
+        this._server = this._createServer();
+        return this._server;
+    }
+
+    async start() {
+        if (!this._conf.testingDisableWSO2AuthStart) {
+            await this._wso2Auth.start();
+        }
+        if (!this._conf.testingDisableServerStart) {
+            await new Promise((resolve) => this._server.listen(this._conf.testPort, resolve));
+            this._logger.log(`Serving test API on port ${this._conf.testPort}`);
+        }
+    }
+
+    async stop() {
+        if (!this._server) {
+            return;
+        }
+        await new Promise(resolve => this._server.close(resolve));
+        this._wso2Auth.stop();
+        console.log('api shut down complete');
+    }
+
+    async _createLogger() {
+        const transports = await Promise.all([Transports.consoleDir()]);
+        // Set up a logger for each running server
+        return new Logger({
+            context: {
+                app: 'mojaloop-sdk-test-api'
+            },
+            space: this._conf.logIndent,
+            transports,
+        });
+    }
+
+    async _createCache() {
+        const transports = await Promise.all([Transports.consoleDir()]);
+        const logger = new Logger({
+            context: {
+                app: 'mojaloop-sdk-inboundCache'
+            },
+            space: this._conf.logIndent,
+            transports,
+        });
+
+        const cacheConfig = {
+            ...this._conf.cacheConfig,
+            logger
+        };
+
+        return new Cache(cacheConfig);
+    }
+
+    _createServer() {
+        let server;
+        // If config specifies TLS, start an HTTPS server; otherwise HTTP
+        if (this._conf.tls.test.mutualTLS.enabled) {
+            const testHttpsOpts = {
+                ...this._conf.tls.test.creds,
+                requestCert: true,
+                rejectUnauthorized: true // no effect if requestCert is not true
+            };
+            server = https.createServer(testHttpsOpts, this._api.callback());
+        } else {
+            server = http.createServer(this._api.callback());
+        }
+        return server;
+    }
+}
+
+module.exports = TestServer;

--- a/src/config.js
+++ b/src/config.js
@@ -30,6 +30,7 @@ const env = from(process.env, {
 module.exports = {
     inboundPort: env.get('INBOUND_LISTEN_PORT').default('4000').asPortNumber(),
     outboundPort: env.get('OUTBOUND_LISTEN_PORT').default('4001').asPortNumber(),
+    testPort: env.get('TEST_LISTEN_PORT').default('4002').asPortNumber(),
     tls: {
         inbound: {
             mutualTLS: {
@@ -49,6 +50,16 @@ module.exports = {
                 ca: env.get('OUT_CA_CERT_PATH').asFileListContent(),
                 cert: env.get('OUT_CLIENT_CERT_PATH').asFileContent(),
                 key: env.get('OUT_CLIENT_KEY_PATH').asFileContent(),
+            },
+        },
+        test: {
+            mutualTLS: {
+                enabled: env.get('TEST_MUTUAL_TLS_ENABLED').default('false').asBool(),
+            },
+            creds: {
+                ca: env.get('TEST_CA_CERT_PATH').asFileListContent(),
+                cert: env.get('TEST_CLIENT_CERT_PATH').asFileContent(),
+                key: env.get('TEST_CLIENT_KEY_PATH').asFileContent(),
             },
         },
     },

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const config = require('./config');
 const InboundServer = require('./InboundServer');
 const OutboundServer = require('./OutboundServer');
 const OAuthTestServer = require('./OAuthTestServer');
+const TestServer = require('./TestServer');
 
 // import things we want to expose e.g. for unit tests and users who dont want to use the entire
 // scheme adapter as a service
@@ -25,7 +26,6 @@ const RandomPhrase = require('@internal/randomphrase');
 const Log = require('@internal/log');
 const Cache = require('@internal/cache');
 
-
 /**
  * Class that creates and manages http servers that expose the scheme adapter APIs.
  */
@@ -35,6 +35,7 @@ class Server {
         this.inboundServer = null;
         this.outboundServer = null;
         this.oauthTestServer = null;
+        this.testServer = null;
     }
 
     async start() {
@@ -46,12 +47,19 @@ class Server {
             port: this.conf.oauthTestServer.listenPort,
             logIndent: this.conf.logIndent,
         });
+        this.testServer = new TestServer(this.conf);
 
         await Promise.all([
             this._startInboundServer(),
             this._startOutboundServer(),
             this._startOAuthTestServer(),
+            this._startTestServer(),
         ]);
+    }
+
+    async _startTestServer() {
+        await this.testServer.setupApi();
+        await this.testServer.start();
     }
 
     async _startInboundServer() {
@@ -76,6 +84,7 @@ class Server {
             this.inboundServer.stop(),
             this.outboundServer.stop(),
             this.oauthTestServer.stop(),
+            this.testServer.stop(),
         ]);
     }
 }

--- a/src/test/unit/TestServer.test.js
+++ b/src/test/unit/TestServer.test.js
@@ -26,11 +26,6 @@ jest.mock('@internal/requests');
 const InboundServer = require('../../InboundServer');
 const TestServer = require('../../TestServer');
 
-// - testserver health check- remember, k8s will kill the pod if this fails
-// - testserver starts- I guess
-// - testserver asks the cache for the same key inboundserver stores on
-// - testserver callbacks _and_ requests
-
 describe('Test Server', () => {
     let testServer, inboundServer, inboundReq, testReq, serverConfig, inboundCache, testCache;
 
@@ -40,12 +35,6 @@ describe('Test Server', () => {
         serverConfig = {
             ...JSON.parse(JSON.stringify(defaultConfig)),
             enableTestFeatures: true,
-            logger: {
-                indent: 2,
-                transports: {
-                    stdout: true
-                }
-            }
         };
 
         testServer = new TestServer(serverConfig);
@@ -72,10 +61,6 @@ describe('Test Server', () => {
         const testArgs = { ...cache.mock.calls[0][0], logger: expect.anything() };
         expect(cache).toHaveBeenNthCalledWith(2, testArgs);
     });
-
-    // test('Inbound server and Test server construct cache with same parameters', async () => {
-    //     const 
-    // });
 
     test('Health check', async () => {
         const result = await testReq.get('/');

--- a/src/test/unit/TestServer.test.js
+++ b/src/test/unit/TestServer.test.js
@@ -1,0 +1,131 @@
+/**************************************************************************
+ *  (C) Copyright ModusBox Inc. 2019 - All rights reserved.               *
+ *                                                                        *
+ *  This file is made available under the terms of the license agreement  *
+ *  specified in the corresponding source code repository.                *
+ *                                                                        *
+ *  ORIGINAL AUTHOR:                                                      *
+ *       James Bush - james.bush@modusbox.com                             *
+ **************************************************************************/
+
+'use strict';
+
+const supertest = require('supertest');
+
+const defaultConfig = require('./data/defaultConfig');
+const putPartiesBody = require('./data/putPartiesBody');
+const postQuotesBody = require('./data/postQuotesBody');
+const putParticipantsBody = require('./data/putParticipantsBody');
+const commonHttpHeaders = require('./data/commonHttpHeaders');
+
+const cache = require('@internal/cache');
+jest.mock('@internal/cache');
+jest.mock('@mojaloop/sdk-standard-components');
+jest.mock('@internal/requests');
+
+const InboundServer = require('../../InboundServer');
+const TestServer = require('../../TestServer');
+
+// - testserver health check- remember, k8s will kill the pod if this fails
+// - testserver starts- I guess
+// - testserver asks the cache for the same key inboundserver stores on
+// - testserver callbacks _and_ requests
+
+describe('Test Server', () => {
+    let testServer, inboundServer, inboundReq, testReq, serverConfig, inboundCache, testCache;
+
+    beforeEach(async () => {
+        cache.mockClear();
+
+        serverConfig = {
+            ...JSON.parse(JSON.stringify(defaultConfig)),
+            enableTestFeatures: true,
+            logger: {
+                indent: 2,
+                transports: {
+                    stdout: true
+                }
+            }
+        };
+
+        testServer = new TestServer(serverConfig);
+        testReq = supertest(await testServer.setupApi());
+        await testServer.start();
+        testCache = cache.mock.instances[0];
+
+        inboundServer = new InboundServer(serverConfig);
+        inboundReq = supertest(await inboundServer.setupApi());
+        await inboundServer.start();
+        inboundCache = cache.mock.instances[1];
+
+        expect(cache).toHaveBeenCalledTimes(2);
+    });
+
+    afterEach(async () => {
+        await testServer.stop();
+        await inboundServer.stop();
+    });
+
+    // TODO: check this happens correctly with top-level server if possible?
+    test('Inbound server and Test server construct cache with same parameters when provided same config', async () => {
+        expect(cache).toHaveBeenCalledTimes(2);
+        const testArgs = { ...cache.mock.calls[0][0], logger: expect.anything() };
+        expect(cache).toHaveBeenNthCalledWith(2, testArgs);
+    });
+
+    // test('Inbound server and Test server construct cache with same parameters', async () => {
+    //     const 
+    // });
+
+    test('Health check', async () => {
+        const result = await testReq.get('/');
+        expect(result.ok).toBeTruthy();
+        expect(result.statusCode).toEqual(204);
+    });
+
+    test('PUT /parties cache get and set use same value', async () => {
+        const MSISDN = '123456789';
+
+        await inboundReq
+            .put(`/parties/MSISDN/${MSISDN}`)
+            .send(putPartiesBody)
+            .set(commonHttpHeaders)
+            .set('fspiop-http-method', 'PUT')
+            .set('fspiop-uri', `/parties/MSISDN/${MSISDN}`)
+            .set('date', new Date().toISOString());
+
+        await testReq.get(`/callbacks/${MSISDN}`);
+
+        expect(inboundCache.set.mock.calls[0][0]).toEqual(testCache.get.mock.calls[0][0]);
+    });
+
+    test('POST /quotes requests cache get and set use same value', async () => {
+        await inboundReq
+            .post('/quotes')
+            .send(postQuotesBody)
+            .set(commonHttpHeaders)
+            .set('fspiop-http-method', 'POST')
+            .set('fspiop-uri', '/quotes')
+            .set('date', new Date().toISOString());
+
+        await testReq.get(`/requests/${postQuotesBody.quoteId}`);
+
+        expect(inboundCache.set.mock.calls[0][0]).toEqual(testCache.get.mock.calls[0][0]);
+    });
+
+    test('PUT /participants callbacks cache get and set use same value', async () => {
+        const participantId = '00000000-0000-1000-a000-000000000002';
+
+        await inboundReq
+            .put(`/participants/${participantId}`)
+            .send(putParticipantsBody)
+            .set(commonHttpHeaders)
+            .set('fspiop-http-method', 'PUT')
+            .set('fspiop-uri', `/participants/${participantId}`)
+            .set('date', new Date().toISOString());
+
+        await testReq.get(`/callbacks/${participantId}`);
+
+        expect(inboundCache.set.mock.calls[0][0]).toEqual(testCache.get.mock.calls[0][0]);
+    });
+});

--- a/src/test/unit/data/defaultConfig.json
+++ b/src/test/unit/data/defaultConfig.json
@@ -13,6 +13,14 @@
   "autoAcceptParty": true,
   "useQuoteSourceFSPAsTransferPayeeFSP": false,
   "tls": {
+    "test": {
+      "mutualTLS": { "enabled": false },
+      "creds": {
+        "ca": null,
+        "cert": null,
+        "key": null
+      }
+    },
     "inbound": {
       "mutualTLS": { "enabled": false },
       "creds": {


### PR DESCRIPTION
A couple of other changes in this PR (although they probably shouldn't be, but I can't be bothered moving them):
- Dockerfile modified to cache node modules and avoid npm install every build
- Labels added to Dockerfile
- Added `.dockerignore` file to reduce docker build context size and avoid pollution by `node_modules`

Before merging, please review this:
https://github.com/msk-/sdk-scheme-adapter/pull/1

Additionally, it looks like the integration tests are not passing- was that the case previously? Is it because I changed the `npm install` command in the Dockerfile to `npm install --production`? I would have _guessed_ not, but I guess it's possible `npm prune --production` doesn't do what it says it does.