### PR TITLE
strip any base path off peerEndpoint config when proxying

### DIFF
--- a/src/OutboundServer/index.js
+++ b/src/OutboundServer/index.js
@@ -25,6 +25,8 @@ const router = require('@internal/router');
 const handlers = require('./handlers');
 const middlewares = require('./middlewares');
 
+const endpointRegex = /\/.*/g;
+
 class OutboundServer {
     constructor(conf) {
         this._conf = conf;
@@ -61,6 +63,7 @@ class OutboundServer {
         if (this._conf.proxyConfig) {
             this._api.use(middlewares.createProxy({
                 ...this._conf,
+                peerEndpoint: this._conf.peerEndpoint.replace(endpointRegex, ''),
                 proxyConfig: this._conf.proxyConfig,
                 logger: this._logger,
                 wso2Auth: this._wso2Auth,

--- a/src/OutboundServer/index.js
+++ b/src/OutboundServer/index.js
@@ -60,6 +60,9 @@ class OutboundServer {
         const sharedState = { cache: this._cache, wso2Auth: this._wso2Auth, conf: this._conf };
         this._api.use(middlewares.createLogger(this._logger, sharedState));
 
+        //Note that we strip off any path on peerEndpoint config after the origin.
+        //this is to allow proxy routed requests to hit any path on the peer origin
+        //irrespective of any base path on the PEER_ENDPOINT setting
         if (this._conf.proxyConfig) {
             this._api.use(middlewares.createProxy({
                 ...this._conf,

--- a/src/lib/model/ProxyModel/index.js
+++ b/src/lib/model/ProxyModel/index.js
@@ -31,6 +31,7 @@ class ProxyModel {
      */
     constructor(config) {
         this._logger = config.logger;
+
         this._requests = new MojaloopRequests({
             logger: this._logger,
             peerEndpoint: config.peerEndpoint,

--- a/src/lib/model/ProxyModel/index.js
+++ b/src/lib/model/ProxyModel/index.js
@@ -15,8 +15,6 @@ const configSchema = require('./configSchema');
 const util = require('util');
 const Route = require('./Route');
 
-const endpointRegex = /\/.*/g;
-
 /**
  * ProxyModel forwards request to corresponding endpoint based on provided route config
  */
@@ -40,7 +38,7 @@ class ProxyModel {
 
         this._requests = new MojaloopRequests({
             logger: this._logger,
-            peerEndpoint: config.peerEndpoint.replace(endpointRegex, ''),
+            peerEndpoint: config.peerEndpoint,
             dfspId: config.dfspId,
             tls: config.tls,
             jwsSign: config.jwsSign,

--- a/src/lib/model/ProxyModel/index.js
+++ b/src/lib/model/ProxyModel/index.js
@@ -15,6 +15,8 @@ const configSchema = require('./configSchema');
 const util = require('util');
 const Route = require('./Route');
 
+const endpointRegex = /\/.*/g;
+
 /**
  * ProxyModel forwards request to corresponding endpoint based on provided route config
  */
@@ -32,9 +34,13 @@ class ProxyModel {
     constructor(config) {
         this._logger = config.logger;
 
+        //Note that we strip off any path on peerEndpoint config after the origin.
+        //this is to allow proxy routed requests to hit any path on the peer origin
+        //irrespective of any base path on the PEER_ENDPOINT setting
+
         this._requests = new MojaloopRequests({
             logger: this._logger,
-            peerEndpoint: config.peerEndpoint,
+            peerEndpoint: config.peerEndpoint.replace(endpointRegex, ''),
             dfspId: config.dfspId,
             tls: config.tls,
             jwsSign: config.jwsSign,

--- a/src/lib/model/ProxyModel/index.js
+++ b/src/lib/model/ProxyModel/index.js
@@ -31,11 +31,6 @@ class ProxyModel {
      */
     constructor(config) {
         this._logger = config.logger;
-
-        //Note that we strip off any path on peerEndpoint config after the origin.
-        //this is to allow proxy routed requests to hit any path on the peer origin
-        //irrespective of any base path on the PEER_ENDPOINT setting
-
         this._requests = new MojaloopRequests({
             logger: this._logger,
             peerEndpoint: config.peerEndpoint,

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "9.4.5",
+  "version": "9.4.6",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {

--- a/src/test/unit/api/proxy/proxy.test.js
+++ b/src/test/unit/api/proxy/proxy.test.js
@@ -23,6 +23,8 @@ const { createProxyTester } = require('./utils');
 
 const defaultConfig = require('../../data/defaultConfig');
 
+defaultConfig.peerEndpoint = `${defaultConfig.peerEndpoint}/abc/def`;
+
 describe('Proxy', () => {
     let serversInfo;
     let testProxy;


### PR DESCRIPTION
strip any base path off peerEndpoint config setting when proxying requests