### PR TITLE
Exposed log transports to config

### DIFF
--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -13,14 +13,14 @@ services:
       context: .
       target: builder
     env_file: ./src/test/config/integration.env
-    volumes: 
+    volumes:
       # - ./src/test:/src/test
       - ./src:/src
       - node_modules:/src/node_modules
     depends_on:
-      - redis 
+      - redis
     command:
       - 'tail -f /dev/null'
-    entrypoint: 
-      - sh 
+    entrypoint:
+      - sh
       - -c

--- a/src/config.js
+++ b/src/config.js
@@ -105,9 +105,6 @@ module.exports = {
         clientSecret: env.get('OAUTH_TOKEN_ENDPOINT_CLIENT_SECRET').asString(),
         listenPort: env.get('OAUTH_TOKEN_ENDPOINT_LISTEN_PORT').asPortNumber(),
     },
-    testServer: {
-        enabled: env.get('ENABLE_TEST_SERVER').default('false').asBool(),
-    },
     wso2Auth: {
         staticToken: env.get('WSO2_BEARER_TOKEN').asString(),
         tokenEndpoint: env.get('OAUTH_TOKEN_ENDPOINT').asString(),

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ class Server {
     }
 
     async _startTestServer() {
-        if (this.conf.testServer.enabled) {
+        if (this.conf.enableTestFeatures) {
             await this.testServer.setupApi();
             await this.testServer.start();
         }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "9.4.8",
+  "version": "9.4.9",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`ENABLE_TEST_FEATURES` and `ENABLE_TEST_SERVER` are codependent config options, so I've replaced one with the other.