### PR TITLE
Do not parse already processed JSON response.

### DIFF
--- a/src/lib/model/lib/requests/common.js
+++ b/src/lib/model/lib/requests/common.js
@@ -65,13 +65,7 @@ const throwOrJson = async (res) => {
         });
     }
 
-    try {
-        // try parsing the body as JSON
-        return JSON.parse(res.data);
-    }
-    catch(err) {
-        throw new HTTPResponseError({ msg: `Error parsing response as JSON: ${err.stack || util.inspect(err)}`, res });
-    }
+    return res.data;
 };
 
 

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "10.1.4",
+  "version": "10.1.5",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Recently introduced request library returns already parsed JSON response by default.