### PR TITLE
Renamed ALS_ENDPOINT_HOST to ALS_ENDPOINT

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -64,7 +64,7 @@ module.exports = {
         },
     },
     peerEndpoint: env.get('PEER_ENDPOINT').required().asString(),
-    alsEndpoint: env.get('ALS_ENDPOINT_HOST').asString(),
+    alsEndpoint: env.get('ALS_ENDPOINT').asString(),
     quotesEndpoint: env.get('QUOTES_ENDPOINT').asString(),
     transfersEndpoint: env.get('TRANSFERS_ENDPOINT').asString(),
     backendEndpoint: env.get('BACKEND_ENDPOINT').required().asString(),

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "10.1.5",
+  "version": "10.5.0",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Previously it was ALS_ENDPOINT. Somehow it is changed to ALS_ENDPOINT_HOST which is not referenced in any file other than config.js.
So reverting this name back to previous one.