### PR TITLE
requests now respond with .data instead of .body

### DIFF
--- a/src/lib/model/InboundTransfersModel.js
+++ b/src/lib/model/InboundTransfersModel.js
@@ -670,9 +670,9 @@ class InboundTransfersModel {
 
         if(err instanceof HTTPResponseError) {
             const e = err.getData();
-            if(e.res && e.res.body) {
+            if(e.res && e.res.data) {
                 try {
-                    const bodyObj = JSON.parse(e.res.body);
+                    const bodyObj = JSON.parse(e.res.data);
                     mojaloopErrorCode = Errors.MojaloopApiErrorCodeFromCode(`${bodyObj.statusCode}`);
                 }
                 catch(ex) {

--- a/src/package.json
+++ b/src/package.json
@@ -29,7 +29,7 @@
     "@internal/router": "file:lib/router",
     "@internal/shared": "file:lib/model/lib/shared",
     "@internal/validate": "file:lib/validate",
-    "@mojaloop/sdk-standard-components": "^10.2.3",
+    "@mojaloop/sdk-standard-components": "10.2.3",
     "ajv": "^6.12.2",
     "co-body": "^6.0.0",
     "dotenv": "^8.2.0",

--- a/src/test/unit/lib/model/InboundTransfersModel.test.js
+++ b/src/test/unit/lib/model/InboundTransfersModel.test.js
@@ -339,7 +339,7 @@ describe('inboundModel', () => {
             BackendRequests.__getTransfers = jest.fn().mockReturnValue(
                 Promise.reject(new HTTPResponseError({
                     res: {
-                        body: JSON.stringify({
+                        data: JSON.stringify({
                             statusCode: '3208'
                         }),
                     }
@@ -512,7 +512,7 @@ describe('inboundModel', () => {
             BackendRequests.__getBulkTransfers = jest.fn().mockReturnValue(
                 Promise.reject(new HTTPResponseError({
                     res: {
-                        body: JSON.stringify({
+                        data: JSON.stringify({
                             statusCode: '3208'
                         }),
                     }


### PR DESCRIPTION
This PR does not contain a regression test for the functionality that has been changed because
1. It's not possible to write a unit test that isn't tied to a specific implementation of the request library used. To avoid the requirement of actually making an HTTP request, we would have to mock the request library used, in which case, we would have to match its API. A unit test mocking the request library but hoping to detect a regression that occurs when the request library API changes has a maintenance cost but no value.
2. The request library used is not expected to change rapidly.

I've fixed the package version for `sdk-standard-components` because `10.6.0` has a bug (missing file) which will prevent anyone from using it.

In further support of this, a (formatted some) log from the scheme adapter:
```
{
  app: 'mojaloop-sdk-inbound-api',
  request: {
    id: 'mammoth-front-yielding-honey',
    path: '/transfers',
    method: 'POST'
  },
  err: '
    {
      "msg": "Request returned non-success status code 500",
      "res": {
        "statusCode": 500,
        "headers": {
          "content-type": "application/json; charset=utf-8",
          "content-length": "51",
          "date": "Fri, 10 Jul 2020 14:58:06 GMT",
          "connection": "keep-alive"
        },
        "data": {
          "statusCode": "5200",
          "message": "Payee limit error"
        }
      }
    }
  ',
  msg: 'Error in prepareTransfer',
  timestamp: '2020-07-10T14:58:06.200Z'
}
{
  app: 'mojaloop-sdk-inbound-api',
  request: {
    id: 'mammoth-front-yielding-honey',
    path: '/transfers',
    method: 'POST'
  },
  mojaloopError: {
    errorInformation: { errorCode: '2001', errorDescription: 'Internal server error' }
  },
  msg: 'Sending error response to DFSPMAD',
  timestamp: '2020-07-10T14:58:06.200Z'
}
```
Note that it the response it receives in the first log entry contains the `.data` field, not the `.body` field. Further note that it subsequently does not produce the correct ML error `errorCode: '2001'` instead of `errorCode: '5200'`.