### PR TITLE
Do not JSON parse already-parsed response data

### DIFF
--- a/src/lib/model/InboundTransfersModel.js
+++ b/src/lib/model/InboundTransfersModel.js
@@ -672,16 +672,8 @@ class InboundTransfersModel {
         if(err instanceof HTTPResponseError) {
             const e = err.getData();
             if(e.res && e.res.data) {
-                try {
-                    const bodyObj = JSON.parse(e.res.data);
-                    mojaloopErrorCode = Errors.MojaloopApiErrorCodeFromCode(`${bodyObj.statusCode}`);
-                }
-                catch(ex) {
-                    // do nothing
-                    this._logger.push({ ex }).log('Error parsing error message body as JSON');
-                }
+                mojaloopErrorCode = Errors.MojaloopApiErrorCodeFromCode(`${e.res.data.statusCode}`);
             }
-
         }
 
         return new Errors.MojaloopFSPIOPError(err, null, null, mojaloopErrorCode).toApiErrorObject();

--- a/src/test/unit/lib/model/InboundTransfersModel.test.js
+++ b/src/test/unit/lib/model/InboundTransfersModel.test.js
@@ -339,9 +339,9 @@ describe('inboundModel', () => {
             BackendRequests.__getTransfers = jest.fn().mockReturnValue(
                 Promise.reject(new HTTPResponseError({
                     res: {
-                        data: JSON.stringify({
+                        data: {
                             statusCode: '3208'
-                        }),
+                        },
                     }
                 })));
 
@@ -512,9 +512,9 @@ describe('inboundModel', () => {
             BackendRequests.__getBulkTransfers = jest.fn().mockReturnValue(
                 Promise.reject(new HTTPResponseError({
                     res: {
-                        data: JSON.stringify({
+                        data: {
                             statusCode: '3208'
-                        }),
+                        },
                     }
                 })));
 


### PR DESCRIPTION
Related to #182, no longer need to parse response data as it's done here:

https://github.com/mojaloop/sdk-standard-components/blob/3ef2e57192fcb67f2ad54564df493d6f47a9fef7/src/lib/request.js#L65