### PR TITLE
Websocket API for test server

### DIFF
--- a/src/InboundServer/handlers.js
+++ b/src/InboundServer/handlers.js
@@ -28,7 +28,7 @@ const getAuthorizationsById = async (ctx) => {
                     headers: ctx.request.headers
                 };
                 const res = await ctx.state.cache.set(`request_${ctx.state.path.params.ID}`, req);
-                ctx.state.logger.log(`Cacheing request : ${util.inspect(res)}`);
+                ctx.state.logger.log(`Caching request : ${util.inspect(res)}`);
             }
 
             // use the transfers model to execute asynchronous stages with the switch
@@ -109,7 +109,7 @@ const getPartiesByTypeAndId = async (ctx) => {
                     headers: ctx.request.headers
                 };
                 const res = await ctx.state.cache.set(`request_${ctx.state.path.params.ID}`, req);
-                ctx.state.logger.log(`Cacheing request : ${util.inspect(res)}`);
+                ctx.state.logger.log(`Caching request : ${util.inspect(res)}`);
             }
 
             // use the transfers model to execute asynchronous stages with the switch
@@ -166,7 +166,7 @@ const postQuotes = async (ctx) => {
                     data: ctx.request.body
                 };
                 const res = await ctx.state.cache.set(`request_${ctx.request.body.quoteId}`, req);
-                ctx.state.logger.log(`Cacheing request: ${util.inspect(res)}`);
+                ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
             // use the transfers model to execute asynchronous stages with the switch
@@ -212,7 +212,7 @@ const postTransfers = async (ctx) => {
                     data: ctx.request.body
                 };
                 const res = await ctx.state.cache.set(`request_${ctx.request.body.transferId}`, req);
-                ctx.state.logger.log(`Cacheing request: ${util.inspect(res)}`);
+                ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
             // use the transfers model to execute asynchronous stages with the switch
@@ -304,7 +304,7 @@ const postTransactionRequests = async (ctx) => {
                     data: ctx.request.body
                 };
                 const res = await ctx.state.cache.set(`request_${ctx.request.body.transactionRequestId}`, req);
-                ctx.state.logger.log(`Cacheing request: ${util.inspect(res)}`);
+                ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
             // use the transfers model to execute asynchronous stages with the switch
@@ -347,7 +347,7 @@ const putAuthorizationsById = async (ctx) => {
             data: ctx.request.body
         };
         const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
-        ctx.state.logger.log(`Cacheing request: ${util.inspect(res)}`);
+        ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
     }
 
     const idValue = ctx.state.path.params.ID;
@@ -434,7 +434,7 @@ const putPartiesByTypeAndId = async (ctx) => {
             data: ctx.request.body
         };
         const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
-        ctx.state.logger.log(`Cacheing request: ${util.inspect(res)}`);
+        ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
     }
 
     const idType = ctx.state.path.params.Type;
@@ -459,7 +459,7 @@ const putQuoteById = async (ctx) => {
             data: ctx.request.body
         };
         const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
-        ctx.state.logger.log(`Cacheing callback: ${util.inspect(res)}`);
+        ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
     // publish an event onto the cache for subscribers to action
@@ -483,7 +483,7 @@ const putTransactionRequestsById = async (ctx) => {
             data: ctx.request.body
         };
         const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
-        ctx.state.logger.log(`Cacheing callback: ${util.inspect(res)}`);
+        ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
     // publish an event onto the cache for subscribers to action
@@ -531,7 +531,7 @@ const putPartiesByTypeAndIdError = async(ctx) => {
             data: ctx.request.body
         };
         const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
-        ctx.state.logger.log(`Cacheing request: ${util.inspect(res)}`);
+        ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
     }
 
     const idType = ctx.state.path.params.Type;
@@ -561,7 +561,7 @@ const putQuotesByIdError = async(ctx) => {
             data: ctx.request.body
         };
         const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
-        ctx.state.logger.log(`Cacheing callback: ${util.inspect(res)}`);
+        ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
     // publish an event onto the cache for subscribers to action
@@ -586,7 +586,7 @@ const putTransfersByIdError = async (ctx) => {
             data: ctx.request.body
         };
         const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
-        ctx.state.logger.log(`Cacheing callback: ${util.inspect(res)}`);
+        ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
     // publish an event onto the cache for subscribers to action
@@ -659,7 +659,7 @@ const postBulkQuotes = async (ctx) => {
                     data: ctx.request.body
                 };
                 const res = await ctx.state.cache.set(`request_${ctx.request.body.bulkQuoteId}`, req);
-                ctx.state.logger.log(`Cacheing request: ${util.inspect(res)}`);
+                ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
             // use the transfers model to execute asynchronous stages with the switch
@@ -699,7 +699,7 @@ const putBulkQuotesById = async (ctx) => {
             data: ctx.request.body
         };
         const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
-        ctx.state.logger.log(`Cacheing callback: ${util.inspect(res)}`);
+        ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
     // publish an event onto the cache for subscribers to action
@@ -723,7 +723,7 @@ const putBulkQuotesByIdError = async(ctx) => {
             data: ctx.request.body
         };
         const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
-        ctx.state.logger.log(`Cacheing callback: ${util.inspect(res)}`);
+        ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
     // publish an event onto the cache for subscribers to action
@@ -796,7 +796,7 @@ const postBulkTransfers = async (ctx) => {
                     data: ctx.request.body
                 };
                 const res = await ctx.state.cache.set(`request_${ctx.request.body.bulkTransferId}`, req);
-                ctx.state.logger.log(`Cacheing request: ${util.inspect(res)}`);
+                ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
             // use the transfers model to execute asynchronous stages with the switch
@@ -836,7 +836,7 @@ const putBulkTransfersById = async (ctx) => {
             data: ctx.request.body
         };
         const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
-        ctx.state.logger.log(`Cacheing callback: ${util.inspect(res)}`);
+        ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
     // publish an event onto the cache for subscribers to action
@@ -860,7 +860,7 @@ const putBulkTransfersByIdError = async(ctx) => {
             data: ctx.request.body
         };
         const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
-        ctx.state.logger.log(`Cacheing callback: ${util.inspect(res)}`);
+        ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
     // publish an event onto the cache for subscribers to action

--- a/src/InboundServer/handlers.js
+++ b/src/InboundServer/handlers.js
@@ -29,7 +29,7 @@ const getAuthorizationsById = async (ctx) => {
                     headers: ctx.request.headers
                 };
                 const res = await cache.set(`${cache.REQUEST_PREFIX}${ctx.state.path.params.ID}`, req);
-                ctx.state.logger.log(`Caching request : ${util.inspect(res)}`);
+                ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
             // use the transfers model to execute asynchronous stages with the switch
@@ -111,7 +111,7 @@ const getPartiesByTypeAndId = async (ctx) => {
                     headers: ctx.request.headers
                 };
                 const res = await cache.set(`${cache.REQUEST_PREFIX}${ctx.state.path.params.ID}`, req);
-                ctx.state.logger.log(`Caching request : ${util.inspect(res)}`);
+                ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
             // use the transfers model to execute asynchronous stages with the switch
@@ -628,7 +628,7 @@ const getBulkQuotesById = async (ctx) => {
                 };
                 const res = await ctx.state.cache.set(
                     `request_${ctx.state.path.params.ID}`, req);
-                ctx.state.logger.log(`Caching request : ${util.inspect(res)}`);
+                ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
             // use the transfers model to execute asynchronous stages with the switch

--- a/src/InboundServer/handlers.js
+++ b/src/InboundServer/handlers.js
@@ -23,11 +23,12 @@ const getAuthorizationsById = async (ctx) => {
     (async () => {
         try {
             if(ctx.state.conf.enableTestFeatures) {
+                const cache = ctx.state.cache;
                 // we are in test mode so cache the request
                 const req = {
                     headers: ctx.request.headers
                 };
-                const res = await ctx.state.cache.set(`request_${ctx.state.path.params.ID}`, req);
+                const res = await cache.set(`${cache.REQUEST_PREFIX}${ctx.state.path.params.ID}`, req);
                 ctx.state.logger.log(`Caching request : ${util.inspect(res)}`);
             }
 
@@ -104,11 +105,12 @@ const getPartiesByTypeAndId = async (ctx) => {
     (async () => {
         try {
             if(ctx.state.conf.enableTestFeatures) {
+                const cache = ctx.state.cache;
                 // we are in test mode so cache the request
                 const req = {
                     headers: ctx.request.headers
                 };
-                const res = await ctx.state.cache.set(`request_${ctx.state.path.params.ID}`, req);
+                const res = await cache.set(`${cache.REQUEST_PREFIX}${ctx.state.path.params.ID}`, req);
                 ctx.state.logger.log(`Caching request : ${util.inspect(res)}`);
             }
 
@@ -160,12 +162,13 @@ const postQuotes = async (ctx) => {
     (async () => {
         try {
             if(ctx.state.conf.enableTestFeatures) {
+                const cache = ctx.state.cache;
                 // we are in test mode so cache the request
                 const req = {
                     headers: ctx.request.headers,
                     data: ctx.request.body
                 };
-                const res = await ctx.state.cache.set(`request_${ctx.request.body.quoteId}`, req);
+                const res = await cache.set(`${cache.REQUEST_PREFIX}${ctx.request.body.quoteId}`, req);
                 ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
@@ -206,12 +209,13 @@ const postTransfers = async (ctx) => {
     (async () => {
         try {
             if(ctx.state.conf.enableTestFeatures) {
+                const cache = ctx.state.cache;
                 // we are in test mode so cache the request
                 const req = {
                     headers: ctx.request.headers,
                     data: ctx.request.body
                 };
-                const res = await ctx.state.cache.set(`request_${ctx.request.body.transferId}`, req);
+                const res = await cache.set(`${cache.REQUEST_PREFIX}${ctx.request.body.transferId}`, req);
                 ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
@@ -298,12 +302,13 @@ const postTransactionRequests = async (ctx) => {
     (async () => {
         try {
             if(ctx.state.conf.enableTestFeatures) {
+                const cache = ctx.state.cache;
                 // we are in test mode so cache the request
                 const req = {
                     headers: ctx.request.headers,
                     data: ctx.request.body
                 };
-                const res = await ctx.state.cache.set(`request_${ctx.request.body.transactionRequestId}`, req);
+                const res = await cache.set(`${cache.REQUEST_PREFIX}${ctx.request.body.transactionRequestId}`, req);
                 ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
@@ -341,12 +346,13 @@ const postTransactionRequests = async (ctx) => {
  */
 const putAuthorizationsById = async (ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
     }
 
@@ -368,12 +374,13 @@ const putAuthorizationsById = async (ctx) => {
  */
 const putParticipantsById = async (ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
@@ -392,12 +399,13 @@ const putParticipantsById = async (ctx) => {
  */
 const putParticipantsByIdError = async (ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
@@ -428,12 +436,13 @@ const putParticipantsByTypeAndId = async (ctx) => {
  */
 const putPartiesByTypeAndId = async (ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
     }
 
@@ -453,12 +462,13 @@ const putPartiesByTypeAndId = async (ctx) => {
  */
 const putQuoteById = async (ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
@@ -477,12 +487,13 @@ const putQuoteById = async (ctx) => {
  */
 const putTransactionRequestsById = async (ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
@@ -501,12 +512,13 @@ const putTransactionRequestsById = async (ctx) => {
  */
 const putTransfersById = async (ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
@@ -525,12 +537,13 @@ const putTransfersById = async (ctx) => {
  */
 const putPartiesByTypeAndIdError = async(ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
     }
 
@@ -555,12 +568,13 @@ const putPartiesByTypeAndIdError = async(ctx) => {
  */
 const putQuotesByIdError = async(ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
@@ -580,12 +594,13 @@ const putQuotesByIdError = async(ctx) => {
  */
 const putTransfersByIdError = async (ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
@@ -653,12 +668,13 @@ const postBulkQuotes = async (ctx) => {
     (async () => {
         try {
             if(ctx.state.conf.enableTestFeatures) {
+                const cache = ctx.state.cache;
                 // we are in test mode so cache the request
                 const req = {
                     headers: ctx.request.headers,
                     data: ctx.request.body
                 };
-                const res = await ctx.state.cache.set(`request_${ctx.request.body.bulkQuoteId}`, req);
+                const res = await cache.set(`${cache.REQUEST_PREFIX}${ctx.request.body.bulkQuoteId}`, req);
                 ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
@@ -693,12 +709,13 @@ const postBulkQuotes = async (ctx) => {
  */
 const putBulkQuotesById = async (ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
@@ -717,12 +734,13 @@ const putBulkQuotesById = async (ctx) => {
  */
 const putBulkQuotesByIdError = async(ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
@@ -790,12 +808,13 @@ const postBulkTransfers = async (ctx) => {
     (async () => {
         try {
             if(ctx.state.conf.enableTestFeatures) {
+                const cache = ctx.state.cache;
                 // we are in test mode so cache the request
                 const req = {
                     headers: ctx.request.headers,
                     data: ctx.request.body
                 };
-                const res = await ctx.state.cache.set(`request_${ctx.request.body.bulkTransferId}`, req);
+                const res = await cache.set(`${cache.REQUEST_PREFIX}${ctx.request.body.bulkTransferId}`, req);
                 ctx.state.logger.log(`Caching request: ${util.inspect(res)}`);
             }
 
@@ -830,12 +849,13 @@ const postBulkTransfers = async (ctx) => {
  */
 const putBulkTransfersById = async (ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 
@@ -854,12 +874,13 @@ const putBulkTransfersById = async (ctx) => {
  */
 const putBulkTransfersByIdError = async(ctx) => {
     if(ctx.state.conf.enableTestFeatures) {
+        const cache = ctx.state.cache;
         // we are in test mode so cache the request
         const req = {
             headers: ctx.request.headers,
             data: ctx.request.body
         };
-        const res = await ctx.state.cache.set(`callback_${ctx.state.path.params.ID}`, req);
+        const res = await cache.set(`${cache.CALLBACK_PREFIX}${ctx.state.path.params.ID}`, req);
         ctx.state.logger.log(`Caching callback: ${util.inspect(res)}`);
     }
 

--- a/src/TestServer/index.js
+++ b/src/TestServer/index.js
@@ -77,7 +77,7 @@ class TestServer {
         if (!this._conf.testingDisableServerStart) {
             this._server.on('upgrade', (req, socket, head) => {
                 this._wsapi.handleUpgrade(req, socket, head, (ws) =>
-                    this._wsapi.emit('connection', ws, req))
+                    this._wsapi.emit('connection', ws, req));
             });
             await new Promise((resolve) => this._server.listen(this._conf.testPort, resolve));
             this._logger.log(`Serving test API on port ${this._conf.testPort}`);
@@ -154,7 +154,7 @@ class TestServer {
         wss.on('connection', (socket, req) => {
             this._wsClients.set(socket, req);
             socket.on('close', () => {
-                this._wsClients.delete(socket)
+                this._wsClients.delete(socket);
             });
         });
 

--- a/src/TestServer/index.js
+++ b/src/TestServer/index.js
@@ -161,7 +161,7 @@ class TestServer {
         wss.on('error', err => {
             // Curtains down
             this._logger.push({ err })
-                .log('Unhandled websocket error occurred. Shutting down gracefully.');
+                .log('Unhandled websocket error occurred. Shutting down.');
             process.exit(1);
         });
 

--- a/src/TestServer/index.js
+++ b/src/TestServer/index.js
@@ -162,7 +162,7 @@ class TestServer {
             // Curtains down
             this._logger.push({ err })
                 .log('Unhandled websocket error occurred. Shutting down gracefully.');
-            process.exitCode = 1;
+            process.exit(1);
         });
 
         wss.on('connection', (socket, req) => {

--- a/src/TestServer/index.js
+++ b/src/TestServer/index.js
@@ -26,6 +26,10 @@ const router = require('@internal/router');
 const handlers = require('./handlers');
 const middlewares = require('../InboundServer/middlewares');
 
+const getWsIp = (req) => req.headers['x-forwarded-for']
+    ? req.headers['x-forwarded-for'].split(/\s*,\s*/)[0]
+    : req.socket.remoteAddress;
+
 class TestServer {
     constructor(conf) {
         this._conf = conf;
@@ -74,20 +78,25 @@ class TestServer {
         if (!this._conf.testingDisableWSO2AuthStart) {
             await this._wso2Auth.start();
         }
-        if (!this._conf.testingDisableServerStart) {
-            this._server.on('upgrade', (req, socket, head) => {
-                this._wsapi.handleUpgrade(req, socket, head, (ws) =>
-                    this._wsapi.emit('connection', ws, req));
-            });
-            await new Promise((resolve) => this._server.listen(this._conf.testPort, resolve));
-            this._logger.log(`Serving test API on port ${this._conf.testPort}`);
-        }
+        this._server.on('upgrade', (req, socket, head) => {
+            this._wsapi.handleUpgrade(req, socket, head, (ws) =>
+                this._wsapi.emit('connection', ws, req));
+        });
+        await new Promise((resolve) => this._server.listen(this._conf.testPort, resolve));
+        this._logger.log(`Serving test API on port ${this._conf.testPort}`);
     }
 
     async stop() {
         if (!this._server) {
             return;
         }
+        await new Promise(resolve => this._wsapi.close(resolve));
+        // If we don't want for all clients to close before shutting down, the socket close
+        // handlers will be called after we return from this function, resulting in behaviour
+        // occurring after the server tells the user it has shutdown.
+        await Promise.all([...this._wsClients.keys()].map(socket =>
+            new Promise(resolve => socket.on('close', resolve))
+        ));
         await new Promise(resolve => this._server.close(resolve));
         this._wso2Auth.stop();
         await this._cache.disconnect();
@@ -152,8 +161,15 @@ class TestServer {
         });
 
         wss.on('connection', (socket, req) => {
+            const logger = this._logger.push({
+                url: req.url,
+                ip: getWsIp(req),
+                remoteAddress: req.socket.remoteAddress,
+            });
+            logger.log('Websocket connection received');
             this._wsClients.set(socket, req);
-            socket.on('close', () => {
+            socket.on('close', (code, reason) => {
+                logger.push({ code, reason }).log('Websocket connection closed');
                 this._wsClients.delete(socket);
             });
         });
@@ -202,7 +218,7 @@ class TestServer {
                     .push({
                         url: req.url,
                         key,
-                        ip: req.socket.remoteAddress,
+                        ip: getWsIp(req),
                         value: keyData,
                         prefix,
                     })

--- a/src/lib/cache/cache.js
+++ b/src/lib/cache/cache.js
@@ -43,7 +43,6 @@ class Cache {
         this._callbackId = 0;
     }
 
-
     /**
      * Connects to a redis server and waits for ready events
      * Note: We create two connections. One for get, set and publish commands
@@ -149,7 +148,13 @@ class Cache {
 
                 // call the callback with the channel name, message and callbackId...
                 // ...(which is useful for unsubscribe)
-                this._callbacks[channel][k](channel, msg, k);
+                try {
+                    this._callbacks[channel][k](channel, msg, k);
+                } catch (err) {
+                    this._logger
+                        .push({ callbackId: k, err })
+                        .log('Unhandled error in cache subscription handler');
+                }
             });
         }
     }
@@ -261,5 +266,6 @@ class Cache {
     }
 }
 
+Cache.EVENT_SET = '__keyevent@0__:set';
 
 module.exports = Cache;

--- a/src/package.json
+++ b/src/package.json
@@ -37,10 +37,10 @@
     "js-yaml": "^3.13.1",
     "koa": "^2.11.0",
     "koa-body": "^4.1.1",
-    "koa-websocket": "^6.0.0",
     "koa2-oauth-server": "^1.0.0",
     "node-fetch": "^2.6.0",
-    "uuidv4": "^6.0.8"
+    "uuidv4": "^6.0.8",
+    "ws": "^7.3.1"
   },
   "devDependencies": {
     "@types/jest": "^25.2.1",

--- a/src/package.json
+++ b/src/package.json
@@ -37,6 +37,7 @@
     "js-yaml": "^3.13.1",
     "koa": "^2.11.0",
     "koa-body": "^4.1.1",
+    "koa-websocket": "^6.0.0",
     "koa2-oauth-server": "^1.0.0",
     "node-fetch": "^2.6.0",
     "uuidv4": "^6.0.8"

--- a/src/test/unit/TestServer.test.js
+++ b/src/test/unit/TestServer.test.js
@@ -29,7 +29,7 @@ const TestServer = require('../../TestServer');
 
 describe('Test Server', () => {
     let testServer, inboundServer, inboundReq, testReq, serverConfig, inboundCache, testCache,
-        wsClients, wsClientMessages;
+        wsClients;
 
     beforeEach(async () => {
         cache.mockClear();
@@ -152,7 +152,7 @@ describe('Test Server', () => {
     test('Configures cache correctly', async () => {
         expect(testServer._cache.setTestMode).toBeCalledTimes(1);
         expect(testServer._cache.setTestMode).toHaveBeenCalledWith(true);
-    });;
+    });
 
     test('WebSocket /callback and / endpoint triggers send to client when callback received to inbound server', async () => {
         const participantId = '00000000-0000-1000-a000-000000000002';
@@ -174,7 +174,7 @@ describe('Test Server', () => {
         // get the callback function that the test server subscribed with, and mock the cache by
         // calling the callback when the inbound server sets a key in the cache.
         const callback = testServer._cache.subscribe.mock.calls[0][1];
-        inboundServer._cache.set = jest.fn(async (key, val) => await callback(
+        inboundServer._cache.set = jest.fn(async (key) => await callback(
             inboundServer._cache.EVENT_SET,
             key,
             1,
@@ -235,7 +235,7 @@ describe('Test Server', () => {
         // get the callback function that the test server subscribed with, and mock the cache by
         // calling the callback when the inbound server sets a key in the cache.
         const callback = testServer._cache.subscribe.mock.calls[0][1];
-        inboundServer._cache.set = jest.fn(async (key, val) => await callback(
+        inboundServer._cache.set = jest.fn(async (key) => await callback(
             inboundServer._cache.EVENT_SET,
             key,
             1,
@@ -294,7 +294,7 @@ describe('Test Server', () => {
         // get the callback function that the test server subscribed with, and mock the cache by
         // calling the callback when the inbound server sets a key in the cache.
         const callback = testServer._cache.subscribe.mock.calls[0][1];
-        inboundServer._cache.set = jest.fn(async (key, val) => await callback(
+        inboundServer._cache.set = jest.fn(async (key) => await callback(
             inboundServer._cache.EVENT_SET,
             key,
             1,

--- a/src/test/unit/TestServer.test.js
+++ b/src/test/unit/TestServer.test.js
@@ -63,8 +63,8 @@ describe('Test Server', () => {
 
         wsClients = {
             root: await createWsClient(serverConfig.testPort, '/'),
-            callbacks: await createWsClient(serverConfig.testPort, '/callback'),
-            requests: await createWsClient(serverConfig.testPort, '/request'),
+            callbacks: await createWsClient(serverConfig.testPort, '/callbacks'),
+            requests: await createWsClient(serverConfig.testPort, '/requests'),
         };
 
         expect(Object.values(wsClients).every((cli) => cli.readyState === WebSocket.OPEN)).toBe(true);
@@ -154,7 +154,7 @@ describe('Test Server', () => {
         expect(testServer._cache.setTestMode).toHaveBeenCalledWith(true);
     });
 
-    test('WebSocket /callback and / endpoint triggers send to client when callback received to inbound server', async () => {
+    test('WebSocket /callbacks and / endpoint triggers send to client when callback received to inbound server', async () => {
         const participantId = '00000000-0000-1000-a000-000000000002';
 
         const headers = {
@@ -166,7 +166,7 @@ describe('Test Server', () => {
 
         const putParticipantWsClient = await createWsClient(
             serverConfig.testPort,
-            `/callback/${participantId}`
+            `/callbacks/${participantId}`
         );
 
         const putParticipantEndpointMessageReceived = new Promise(resolve => {
@@ -226,7 +226,7 @@ describe('Test Server', () => {
         expect(putParticipantClientClientResult).toEqual(expectedMessage);
     });
 
-    test('WebSocket /request and / endpoint triggers send to client when callback received to inbound server', async () => {
+    test('WebSocket /requests and / endpoint triggers send to client when callback received to inbound server', async () => {
         const headers = {
             ...commonHttpHeaders,
             'fspiop-http-method': 'POST',
@@ -236,7 +236,7 @@ describe('Test Server', () => {
 
         const postQuoteWsClient = await createWsClient(
             serverConfig.testPort,
-            `/request/${postQuotesBody.quoteId}`
+            `/requests/${postQuotesBody.quoteId}`
         );
 
         const postQuoteEndpointMessageReceived = new Promise(resolve => {

--- a/src/test/unit/data/defaultConfig.json
+++ b/src/test/unit/data/defaultConfig.json
@@ -1,6 +1,7 @@
 {
   "inboundPort": 4000,
   "outboundPort": 4001,
+  "testPort": 4002,
   "peerEndpoint": "172.17.0.2:3001",
   "backendEndpoint": "172.17.0.2:3001",
   "alsEndpoint": "127.0.0.1:6500",


### PR DESCRIPTION
### Motivation

Currently a vast range of tests that use the test server do something like this:
1. initiate some action in the switch
2. wait some predetermined time, `w`
3. using `/callbacks` or `/requests`, verify whether the action was completed as expected

The problem arises at (2). If `w` is too short, the test will likely fail. If `w` is too long, the test will take longer than necessary. This is exacerbated by environmental differences. To take two extremes: running on a 1000 processor, 1000TB cluster `w` will be very different to a cluster comprised of a handful of Raspberry Pis. The large cluster will wait _far longer_ than it needs to. The small cluster might attempt step (3) before the action has completed, causing a false negative test result.

Moreover, in order to define `w` for a given test `T`, one might run `T` multiple times to determine a good value for `u`. This leads to:
1. A _lot_ of effort to determine a good value for `u` for _every_ test, for _every_ cluster spec, multiplied over very many possible configurations.
2. An _expected failure rate_ corresponding to the chosen value of `u` and the system specification.

In other words, flaky tests.

This PR means that a test can set a high global test timeout config, say 60 seconds, and then wait for a notification that its event has occurred. This completely eliminates the problem highlighted above.

### Some potential points of implementation contention:
* Constants on Cache might be considered to be more of an application concern and less of a cache concern. Counterpoint: Cache is a Redis abstraction specifically for this application.
* Could explicitly pub/sub instead of using keyevent notifications. The change in this PR seemed like the smaller change, but is less philosophically pure.
* Configuration of redis keyevent notifications by the test server (when `ENABLE_TEST_FEATURES` is `true`).