### PR TITLE
Add ISO-4217 test currencies to enable production testing scenarios.

### DIFF
--- a/docs/dfspInboundApi.yaml
+++ b/docs/dfspInboundApi.yaml
@@ -363,6 +363,8 @@ components:
       - XDR
       - XOF
       - XPF
+      - XTS
+      - XXX
       - YER
       - ZAR
       - ZMW

--- a/src/InboundServer/api.yaml
+++ b/src/InboundServer/api.yaml
@@ -3145,6 +3145,8 @@ components:
         - XDR
         - XOF
         - XPF
+        - XTS
+        - XXX
         - YER
         - ZAR
         - ZMW

--- a/src/OutboundServer/api.yaml
+++ b/src/OutboundServer/api.yaml
@@ -529,6 +529,8 @@ components:
       - XDR
       - XOF
       - XPF
+      - XTS
+      - XXX
       - YER
       - ZAR
       - ZMW

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "11.1.0",
+  "version": "11.1.1",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adding XTS and XXX test currencies to enable testing on production environments without using live currencies.