### PR TITLE
Bugfix/add transaction request service endpoint config

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -56,14 +56,15 @@ CACHE_HOST=172.17.0.2
 CACHE_PORT=6379
 
 # SWITCH ENDPOINT
-# The option 'PEER_ENDPOINT' has no effect if the remaining five options 'ALS_ENDPOINT', 'QUOTES_ENDPOINT',
-# 'BULK_QUOTES_ENDPOINT', 'TRANSFERS_ENDPOINT', 'BULK_TRANSFERS_ENDPOINT' are specified.
+# The option 'PEER_ENDPOINT' has no effect if the remaining options 'ALS_ENDPOINT', 'QUOTES_ENDPOINT',
+# 'BULK_QUOTES_ENDPOINT', 'TRANSFERS_ENDPOINT', 'BULK_TRANSFERS_ENDPOINT', 'TRANSACTION_REQUESTS_ENDPOINT' are specified.
 PEER_ENDPOINT=172.17.0.3:4000
 #ALS_ENDPOINT=account-lookup-service.local
 #QUOTES_ENDPOINT=quoting-service.local
 #BULK_QUOTES_ENDPOINT=quoting-service.local
 #TRANSFERS_ENDPOINT=ml-api-adapter.local
 #BULK_TRANSFERS_ENDPOINT=bulk-api-adapter.local
+#TRANSACTION_REQUESTS_ENDPOINT=transaction-requests-service.local
 
 # BACKEND ENDPOINT
 BACKEND_ENDPOINT=172.17.0.5:4000

--- a/src/config.js
+++ b/src/config.js
@@ -97,6 +97,7 @@ module.exports = {
     alsEndpoint: env.get('ALS_ENDPOINT').asString(),
     quotesEndpoint: env.get('QUOTES_ENDPOINT').asString(),
     bulkQuotesEndpoint: env.get('BULK_QUOTES_ENDPOINT').asString(),
+    transactionRequestsEndpoint: env.get('TRANSACTION_REQUESTS_ENDPOINT').asString(),
     transfersEndpoint: env.get('TRANSFERS_ENDPOINT').asString(),
     bulkTransfersEndpoint: env.get('BULK_TRANSFERS_ENDPOINT').asString(),
     backendEndpoint: env.get('BACKEND_ENDPOINT').required().asString(),

--- a/src/lib/model/InboundTransfersModel.js
+++ b/src/lib/model/InboundTransfersModel.js
@@ -42,6 +42,7 @@ class InboundTransfersModel {
             quotesEndpoint: config.quotesEndpoint,
             transfersEndpoint: config.transfersEndpoint,
             bulkTransfersEndpoint: config.bulkTransfersEndpoint,
+            transactionRequestsEndpoint: config.transactionRequestsEndpoint,
             dfspId: config.dfspId,
             tls: config.tls,
             jwsSign: config.jwsSign,

--- a/src/lib/model/OutboundTransfersModel.js
+++ b/src/lib/model/OutboundTransfersModel.js
@@ -48,6 +48,7 @@ class OutboundTransfersModel {
             alsEndpoint: config.alsEndpoint,
             quotesEndpoint: config.quotesEndpoint,
             transfersEndpoint: config.transfersEndpoint,
+            transactionRequestsEndpoint: config.transactionRequestsEndpoint,
             dfspId: config.dfspId,
             tls: config.tls,
             jwsSign: config.jwsSign,

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "11.2.4",
+  "version": "11.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "11.2.4",
+  "version": "11.2.5",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {

--- a/src/test/config/integration.env
+++ b/src/test/config/integration.env
@@ -49,12 +49,14 @@ CACHE_SHOULD_EXPIRE=false
 CACHE_EXPIRY_SECONDS=3600
 
 # SWITCH ENDPOINT
-# The option 'PEER_ENDPOINT' has no effect if the remaining three options 'ALS_ENDPOINT', 'QUOTES_ENDPOINT', 'TRANSFERS_ENDPOINT' are specified.
+# The option 'PEER_ENDPOINT' has no effect if the remaining options 'ALS_ENDPOINT', 'QUOTES_ENDPOINT',
+# 'BULK_QUOTES_ENDPOINT', 'TRANSFERS_ENDPOINT', 'BULK_TRANSFERS_ENDPOINT', 'TRANSACTION_REQUESTS_ENDPOINT' are specified.
 PEER_ENDPOINT=172.17.0.3:4000
 #ALS_ENDPOINT=account-lookup-service.local
 #QUOTES_ENDPOINT=quoting-service.local
 #TRANSFERS_ENDPOINT=ml-api-adapter.local
 #BULK_TRANSFERS_ENDPOINT=bulk-api-adapter.local
+#TRANSACTION_REQUESTS_ENDPOINT=transaction-requests-service.local
 
 # BACKEND ENDPOINT
 BACKEND_ENDPOINT=172.17.0.5:4000


### PR DESCRIPTION
**Bug:** When we try to send POST /transactionRequests to the sdk-scheme-adapter, its not able to send the callback.

**Fix:** Added `transactionRequestsEndpoint` and `TRANSACTION_REQUESTS_ENDPOINT` which are missing in the sdk-scheme-adapter. Where as sdk-standard-components library is expecting the config param 'transactionRequestsEndpoint' from sdk-scheme-adapter.