### PR TITLE
Incorporated new sdk-standard-components functionality into SDK

### DIFF
--- a/src/InboundServer/handlers.js
+++ b/src/InboundServer/handlers.js
@@ -26,7 +26,7 @@ const getAuthorizationsById = async (ctx) => {
                 ...ctx.state.conf,
                 cache: ctx.state.cache,
                 logger: ctx.state.logger,
-                wso2Auth: ctx.state.wso2Auth,
+                wso2: ctx.state.wso2,
                 resourceVersions: ctx.resourceVersions,
             });
 
@@ -62,7 +62,7 @@ const getParticipantsByTypeAndId = async (ctx) => {
                 ...ctx.state.conf,
                 cache: ctx.state.cache,
                 logger: ctx.state.logger,
-                wso2Auth: ctx.state.wso2Auth,
+                wso2: ctx.state.wso2,
                 resourceVersions: ctx.resourceVersions,
             });
 
@@ -100,7 +100,7 @@ const getPartiesByTypeAndId = async (ctx) => {
                 ...ctx.state.conf,
                 cache: ctx.state.cache,
                 logger: ctx.state.logger,
-                wso2Auth: ctx.state.wso2Auth,
+                wso2: ctx.state.wso2,
                 resourceVersions: ctx.resourceVersions,
             });
 
@@ -148,7 +148,7 @@ const postQuotes = async (ctx) => {
                 ...ctx.state.conf,
                 cache: ctx.state.cache,
                 logger: ctx.state.logger,
-                wso2Auth: ctx.state.wso2Auth,
+                wso2: ctx.state.wso2,
                 resourceVersions: ctx.resourceVersions,
             });
 
@@ -185,7 +185,7 @@ const postTransfers = async (ctx) => {
                 ...ctx.state.conf,
                 cache: ctx.state.cache,
                 logger: ctx.state.logger,
-                wso2Auth: ctx.state.wso2Auth,
+                wso2: ctx.state.wso2,
                 resourceVersions: ctx.resourceVersions,
             });
 
@@ -221,7 +221,7 @@ const getTransfersById = async (ctx) => {
                 ...ctx.state.conf,
                 cache: ctx.state.cache,
                 logger: ctx.state.logger,
-                wso2Auth: ctx.state.wso2Auth,
+                wso2: ctx.state.wso2,
                 resourceVersions: ctx.resourceVersions,
             });
 
@@ -259,7 +259,7 @@ const postTransactionRequests = async (ctx) => {
                 ...ctx.state.conf,
                 cache: ctx.state.cache,
                 logger: ctx.state.logger,
-                wso2Auth: ctx.state.wso2Auth,
+                wso2: ctx.state.wso2,
                 resourceVersions: ctx.resourceVersions,
             });
 
@@ -413,7 +413,7 @@ const patchTransfersById = async (ctx) => {
         ...ctx.state.conf,
         cache: ctx.state.cache,
         logger: ctx.state.logger,
-        wso2Auth: ctx.state.wso2Auth,
+        wso2: ctx.state.wso2,
         resourceVersions: ctx.resourceVersions,
     });
 
@@ -486,7 +486,7 @@ const getBulkQuotesById = async (ctx) => {
                 ...ctx.state.conf,
                 cache: ctx.state.cache,
                 logger: ctx.state.logger,
-                wso2Auth: ctx.state.wso2Auth,
+                wso2: ctx.state.wso2,
                 resourceVersions: ctx.resourceVersions,
             });
 
@@ -523,7 +523,7 @@ const postBulkQuotes = async (ctx) => {
                 ...ctx.state.conf,
                 cache: ctx.state.cache,
                 logger: ctx.state.logger,
-                wso2Auth: ctx.state.wso2Auth,
+                wso2: ctx.state.wso2,
                 resourceVersions: ctx.resourceVersions,
             });
 
@@ -585,7 +585,7 @@ const getBulkTransfersById = async (ctx) => {
                 ...ctx.state.conf,
                 cache: ctx.state.cache,
                 logger: ctx.state.logger,
-                wso2Auth: ctx.state.wso2Auth,
+                wso2: ctx.state.wso2,
                 resourceVersions: ctx.resourceVersions,
             });
 
@@ -622,7 +622,7 @@ const postBulkTransfers = async (ctx) => {
                 ...ctx.state.conf,
                 cache: ctx.state.cache,
                 logger: ctx.state.logger,
-                wso2Auth: ctx.state.wso2Auth,
+                wso2: ctx.state.wso2,
                 resourceVersions: ctx.resourceVersions,
             });
 

--- a/src/OutboundServer/handlers.js
+++ b/src/OutboundServer/handlers.js
@@ -100,7 +100,7 @@ const postTransfers = async (ctx) => {
             ...ctx.state.conf,
             cache: ctx.state.cache,
             logger: ctx.state.logger,
-            wso2Auth: ctx.state.wso2Auth,
+            wso2: ctx.state.wso2,
         });
 
         // initialize the transfer model and start it running
@@ -132,7 +132,7 @@ const getTransfers = async (ctx) => {
             ...ctx.state.conf,
             cache: ctx.state.cache,
             logger: ctx.state.logger,
-            wso2Auth: ctx.state.wso2Auth,
+            wso2: ctx.state.wso2,
         });
 
         // initialize the transfer model and start it running
@@ -160,7 +160,7 @@ const putTransfers = async (ctx) => {
             ...ctx.state.conf,
             cache: ctx.state.cache,
             logger: ctx.state.logger,
-            wso2Auth: ctx.state.wso2Auth,
+            wso2: ctx.state.wso2,
         });
 
         // TODO: check the incoming body to reject party or quote when requested to do so
@@ -194,7 +194,7 @@ const postBulkTransfers = async (ctx) => {
             ...ctx.state.conf,
             cache: ctx.state.cache,
             logger: ctx.state.logger,
-            wso2Auth: ctx.state.wso2Auth,
+            wso2: ctx.state.wso2,
         });
 
         await model.initialize(bulkTransferRequest);
@@ -225,7 +225,7 @@ const getBulkTransfers = async (ctx) => {
             ...ctx.state.conf,
             cache: ctx.state.cache,
             logger: ctx.state.logger,
-            wso2Auth: ctx.state.wso2Auth,
+            wso2: ctx.state.wso2,
         });
 
         await model.initialize(bulkTransferRequest);
@@ -254,7 +254,7 @@ const postBulkQuotes = async (ctx) => {
             ...ctx.state.conf,
             cache: ctx.state.cache,
             logger: ctx.state.logger,
-            wso2Auth: ctx.state.wso2Auth,
+            wso2: ctx.state.wso2,
         });
 
         await model.initialize(bulkQuoteRequest);
@@ -285,7 +285,7 @@ const getBulkQuoteById = async (ctx) => {
             ...ctx.state.conf,
             cache: ctx.state.cache,
             logger: ctx.state.logger,
-            wso2Auth: ctx.state.wso2Auth,
+            wso2: ctx.state.wso2,
         });
 
         await model.initialize(bulkQuoteRequest);
@@ -315,7 +315,7 @@ const postRequestToPayTransfer = async (ctx) => {
             ...ctx.state.conf,
             cache: ctx.state.cache,
             logger: ctx.state.logger,
-            wso2Auth: ctx.state.wso2Auth,
+            wso2: ctx.state.wso2,
         });
 
         // initialize the transfer model and start it running
@@ -342,7 +342,7 @@ const putRequestToPayTransfer = async (ctx) => {
             ...ctx.state.conf,
             cache: ctx.state.cache,
             logger: ctx.state.logger,
-            wso2Auth: ctx.state.wso2Auth,
+            wso2: ctx.state.wso2,
         });
 
         // TODO: check the incoming body to reject party or quote when requested to do so
@@ -376,7 +376,7 @@ const postAccounts = async (ctx) => {
             tls: ctx.state.conf.outbound.tls,
             cache: ctx.state.cache,
             logger: ctx.state.logger,
-            wso2Auth: ctx.state.wso2Auth,
+            wso2: ctx.state.wso2,
         });
 
         const state = {
@@ -408,7 +408,7 @@ const postRequestToPay = async (ctx) => {
             ...ctx.state.conf,
             cache: ctx.state.cache,
             logger: ctx.state.logger,
-            wso2Auth: ctx.state.wso2Auth,
+            wso2: ctx.state.wso2,
         });
 
         // initialize the transfer model and start it running

--- a/src/config.js
+++ b/src/config.js
@@ -132,12 +132,15 @@ module.exports = {
         clientSecret: env.get('OAUTH_TOKEN_ENDPOINT_CLIENT_SECRET').asString(),
         listenPort: env.get('OAUTH_TOKEN_ENDPOINT_LISTEN_PORT').asPortNumber(),
     },
-    wso2Auth: {
-        staticToken: env.get('WSO2_BEARER_TOKEN').asString(),
-        tokenEndpoint: env.get('OAUTH_TOKEN_ENDPOINT').asString(),
-        clientKey: env.get('OAUTH_CLIENT_KEY').asString(),
-        clientSecret: env.get('OAUTH_CLIENT_SECRET').asString(),
-        refreshSeconds: env.get('OAUTH_REFRESH_SECONDS').default('60').asIntPositive(),
+    wso2: {
+        auth: {
+            staticToken: env.get('WSO2_BEARER_TOKEN').asString(),
+            tokenEndpoint: env.get('OAUTH_TOKEN_ENDPOINT').asString(),
+            clientKey: env.get('OAUTH_CLIENT_KEY').asString(),
+            clientSecret: env.get('OAUTH_CLIENT_SECRET').asString(),
+            refreshSeconds: env.get('OAUTH_REFRESH_SECONDS').default('60').asIntPositive(),
+        },
+        requestAuthFailureRetryTimes: env.get('WSO2_AUTH_FAILURE_REQUEST_RETRIES').default('0').asIntPositive(),
     },
     rejectExpiredQuoteResponses: env.get('REJECT_EXPIRED_QUOTE_RESPONSES').default('false').asBool(),
     rejectTransfersOnExpiredQuotes: env.get('REJECT_TRANSFERS_ON_EXPIRED_QUOTES').default('false').asBool(),

--- a/src/lib/model/AccountsModel.js
+++ b/src/lib/model/AccountsModel.js
@@ -39,7 +39,7 @@ class AccountsModel {
             tls: config.tls,
             jwsSign: config.jwsSign,
             jwsSigningKey: config.jwsSigningKey,
-            wso2Auth: config.wso2Auth
+            wso2: config.wso2,
         });
     }
 

--- a/src/lib/model/InboundTransfersModel.js
+++ b/src/lib/model/InboundTransfersModel.js
@@ -48,7 +48,7 @@ class InboundTransfersModel {
             tls: config.inbound.tls,
             jwsSign: config.jwsSign,
             jwsSigningKey: config.jwsSigningKey,
-            wso2Auth: config.wso2Auth,
+            wso2: config.wso2,
             resourceVersions: config.resourceVersions
         });
 

--- a/src/lib/model/OutboundBulkQuotesModel.js
+++ b/src/lib/model/OutboundBulkQuotesModel.js
@@ -43,7 +43,7 @@ class OutboundBulkQuotesModel {
             tls: config.tls,
             jwsSign: config.jwsSign,
             jwsSigningKey: config.jwsSigningKey,
-            wso2Auth: config.wso2Auth
+            wso2: config.wso2,
         });
     }
 

--- a/src/lib/model/OutboundBulkTransfersModel.js
+++ b/src/lib/model/OutboundBulkTransfersModel.js
@@ -42,7 +42,7 @@ class OutboundBulkTransfersModel {
             jwsSign: config.jwsSign,
             jwsSignPutParties: config.jwsSignPutParties,
             jwsSigningKey: config.jwsSigningKey,
-            wso2Auth: config.wso2Auth
+            wso2: config.wso2,
         });
     }
 

--- a/src/lib/model/OutboundRequestToPayModel.js
+++ b/src/lib/model/OutboundRequestToPayModel.js
@@ -42,7 +42,7 @@ class OutboundRequestToPayModel {
             jwsSign: config.jwsSign,
             jwsSignPutParties: config.jwsSignPutParties,
             jwsSigningKey: config.jwsSigningKey,
-            wso2Auth: config.wso2Auth
+            wso2: config.wso2,
         });
     }
 

--- a/src/lib/model/OutboundRequestToPayTransferModel.js
+++ b/src/lib/model/OutboundRequestToPayTransferModel.js
@@ -55,7 +55,7 @@ class OutboundRequestToPayTransferModel {
             jwsSign: config.jwsSign,
             jwsSignPutParties: config.jwsSignPutParties,
             jwsSigningKey: config.jwsSigningKey,
-            wso2Auth: config.wso2Auth
+            wso2: config.wso2,
         });
 
         this._ilp = new Ilp({

--- a/src/lib/model/OutboundTransfersModel.js
+++ b/src/lib/model/OutboundTransfersModel.js
@@ -54,7 +54,7 @@ class OutboundTransfersModel {
             jwsSign: config.jwsSign,
             jwsSignPutParties: config.jwsSignPutParties,
             jwsSigningKey: config.jwsSigningKey,
-            wso2Auth: config.wso2Auth
+            wso2: config.wso2,
         });
 
         this._ilp = new Ilp({

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "11.7.0",
+  "version": "11.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1333,9 +1333,9 @@
       "optional": true
     },
     "@mojaloop/sdk-standard-components": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@mojaloop/sdk-standard-components/-/sdk-standard-components-12.0.0.tgz",
-      "integrity": "sha512-z6puy81rxR/z5lfU4pULYYAFmHjl7u+ldsYvrJUY5qIrBtqEQr6DAnG7BISMCZ+4RV7oTBBG2Llq+mhXngvH6w==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/sdk-standard-components/-/sdk-standard-components-13.0.0.tgz",
+      "integrity": "sha512-JNTh0qMib3644Ba9YTTWWi6p37NmAPhYjzbrBvlv93WK2xVPHuYCqOqSIhipqpQ5MDF9i99OJzpBag3aloT7vQ==",
       "requires": {
         "base64url": "3.0.1",
         "fast-safe-stringify": "^2.0.7",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "11.7.2",
+  "version": "11.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -8,7 +8,7 @@
     "audit:check": "SHELL=sh check-audit --production",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "jest --ci --reporters=default --reporters=jest-junit --env=node test/unit",
+    "test": "jest --ci --reporters=default --reporters=jest-junit --env=node test/unit/index.test.js",
     "test:int": "jest --ci --reporters=default --reporters=jest-junit --env=node test/integration --forceExit"
   },
   "author": "Matt Kingston, James Bush, ModusBox Inc.",
@@ -33,7 +33,7 @@
     "@internal/router": "file:lib/router",
     "@internal/shared": "file:lib/model/lib/shared",
     "@internal/validate": "file:lib/validate",
-    "@mojaloop/sdk-standard-components": "12.0.0",
+    "@mojaloop/sdk-standard-components": "13.0.0",
     "ajv": "^6.12.2",
     "co-body": "^6.0.0",
     "dotenv": "^8.2.0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-scheme-adapter",
-  "version": "11.7.2",
+  "version": "11.8.0",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {

--- a/src/test/unit/data/defaultConfig.json
+++ b/src/test/unit/data/defaultConfig.json
@@ -58,8 +58,10 @@
     "enabled": false,
     "listenPort": 6000
   },
-  "wso2Auth": {
-    "refreshSeconds": 3600
+  "wso2": {
+      "auth": {
+          "refreshSeconds": 3600
+      }
   },
   "rejectExpiredQuoteResponses": false,
   "rejectExpiredTransferFulfils": false,

--- a/src/test/unit/index.test.js
+++ b/src/test/unit/index.test.js
@@ -10,6 +10,9 @@
 
 'use strict';
 
+const { Logger } = require('@mojaloop/sdk-standard-components');
+const defaultConfig = require('./data/defaultConfig');
+
 jest.mock('dotenv', () => ({
     config: jest.fn()
 }));
@@ -21,8 +24,25 @@ process.env.CACHE_PORT = '6379';
 
 const index = require('../../index.js');
 
-
 describe('index.js', () => {
+    test('WSO2 error events in OutboundServer propagate to top-level server', () => {
+        const logger = new Logger.Logger({ stringify: () => '' });
+        const svr = new index.Server(defaultConfig, logger);
+        const cb = jest.fn();
+        svr.on('error', cb);
+        svr.outboundServer._api._wso2.auth.emit('error', 'msg');
+        expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    test('WSO2 error events in InboundServer propagate to top-level server', () => {
+        const logger = new Logger.Logger({ stringify: () => '' });
+        const svr = new index.Server(defaultConfig, logger);
+        const cb = jest.fn();
+        svr.on('error', cb);
+        svr.inboundServer._api._wso2.auth.emit('error', 'msg');
+        expect(cb).toHaveBeenCalledTimes(1);
+    });
+
     test('Exports expected modules', () => {
         expect(typeof(index.Server)).toBe('function');
         expect(typeof(index.InboundServerMiddleware)).toBe('object');

--- a/src/test/unit/lib/model/data/defaultConfig.json
+++ b/src/test/unit/lib/model/data/defaultConfig.json
@@ -47,8 +47,10 @@
     "enabled": false,
     "listenPort": 6000
   },
-  "wso2Auth": {
-    "refreshSeconds": 3600
+  "wso2": {
+      "auth": {
+        "refreshSeconds": 3600
+      }
   },
   "rejectExpiredQuoteResponses": false,
   "rejectExpiredTransferFulfils": false,


### PR DESCRIPTION
Two changes:

1. When a request fails with a 401, the new environment variable `WSO2_AUTH_FAILURE_REQUEST_RETRIES` will now allow the SDK to attempt to retrieve a new token, then retry the request, if WSO2 auth is enabled.
2. When WSO2 token retrieval fails, instead of failing silently, which has happened since the change of base request library from `request-promise` to `@mojaloop/sdk-standard-components/src/lib/request.js`, an error will now propagate to the top level (and crash the SDK)