### PR TITLE
fix(mojaloop/#2436): sdk-sch-adapter inb-API responds incorrectly for 'Unknown uri' error scenario

### DIFF
--- a/src/InboundServer/middlewares.js
+++ b/src/InboundServer/middlewares.js
@@ -184,8 +184,7 @@ const createHeaderValidator = (logger) => async (
 
     // Only validate requests for the requested resources
     if (!resources.includes(resource)) {
-        await next();
-        return;
+        return await next();
     }
 
     // Always validate the accept header for a get request, or optionally if it has been


### PR DESCRIPTION
- Fix for [mojaloop/#2436](https://github.com/mojaloop/project/issues/2436) Inbound API Middleware for createHeaderValidator function would continue validating even if the resource was invalid, thereby replacing the Interface OpenAPI Validation of the createRequestValidator Middleware.