### PR TITLE
chore: added .npmignore so that the test folder is not included when publishing packages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# Ignore tests for publishing
+test/*

--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -59,6 +59,11 @@
       "decision": "ignore",
       "madeAt": 1657217280998,
       "expiresAt": 1659809259103
+    },
+    "1081008|@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>protobufjs>moment": {
+      "decision": "ignore",
+      "madeAt": 1657621042651,
+      "expiresAt": 1660213039412
     }
   },
   "rules": {},


### PR DESCRIPTION
This is to fix Image Scans picking up unnecessary `test/data` folder in the Unit/Integration tests which contain dummy keys, ref: https://app.circleci.com/pipelines/github/mojaloop/simulator/215/workflows/56f815aa-b521-4a20-b43e-ee8edc9cb6da/jobs/1862