### PR TITLE
feat(mojaloop/#2883): add SDKOutboundBulkPartyInfoRequested domain event handler

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -12,6 +12,9 @@
         "GHSA-rjqq-98f6-6j3r",
         "GHSA-phwq-j96m-2c2q",
         "GHSA-pfrx-2q88-qq97",
-        "GHSA-wc69-rhjr-hc9g"
+        "GHSA-wc69-rhjr-hc9g",
+        "GHSA-3cvr-822r-rqcc",
+        "GHSA-8qr4-xgw6-wmr3",
+        "GHSA-f772-66g8-q5h3"
     ]
 }

--- a/modules/outbound-command-event-handler/src/domain/bulk_transaction_agg/handlers/process_party_info_callback.ts
+++ b/modules/outbound-command-event-handler/src/domain/bulk_transaction_agg/handlers/process_party_info_callback.ts
@@ -25,7 +25,7 @@
 'use strict';
 
 import { ILogger } from '@mojaloop/logging-bc-public-types-lib';
-import { CommandEventMessage, ProcessPartyInfoCallbackMessage, PartyInfoCallbackProceededMessage } from '@mojaloop/sdk-scheme-adapter-private-shared-lib';
+import { CommandEventMessage, ProcessPartyInfoCallbackMessage, PartyInfoCallbackProcessedMessage } from '@mojaloop/sdk-scheme-adapter-private-shared-lib';
 import { BulkTransactionAgg } from '..';
 import { ICommandEventHandlerOptions } from '@module-types';
 import { IndividualTransferInternalState } from '../..';
@@ -60,7 +60,7 @@ export async function handleProcessPartyInfoCallbackMessage(
         }
         individualTransfer.setPartyResponse(partyResult);
 
-        const msg = new PartyInfoCallbackProceededMessage({
+        const msg = new PartyInfoCallbackProcessedMessage({
             key: processPartyInfoCallbackMessage.getKey(),
             timestamp: Date.now(),
             headers: [],

--- a/modules/outbound-command-event-handler/src/domain/bulk_transaction_agg/index.ts
+++ b/modules/outbound-command-event-handler/src/domain/bulk_transaction_agg/index.ts
@@ -174,7 +174,7 @@ export class BulkTransactionAgg extends BaseAggregate<BulkTransactionEntity, Bul
         options: ICommandEventHandlerOptions,
         logger: ILogger,
     ) {
-        const handlerPrefix = 'handle'
+        const handlerPrefix = 'handle';
         if(!CommandEventHandlerFuntions.hasOwnProperty(handlerPrefix + message.constructor.name)) {
             logger.error(`Handler function for the command event message ${message.constructor.name} is not implemented`);
             return;

--- a/modules/outbound-command-event-handler/src/infrastructure/inmemory_bulk_transaction_repo.ts
+++ b/modules/outbound-command-event-handler/src/infrastructure/inmemory_bulk_transaction_repo.ts
@@ -37,6 +37,7 @@ export class InMemoryBulkTransactionStateRepo implements IBulkTransactionEntityR
     private _initialized = false;
 
     private readonly keyPrefix: string = 'outboundBulkTransaction_';
+
     private readonly individualTransferKeyPrefix: string = 'individualItem_';
 
 

--- a/modules/outbound-domain-event-handler/src/application/handler.ts
+++ b/modules/outbound-domain-event-handler/src/application/handler.ts
@@ -31,13 +31,14 @@ import {
     KafkaCommandEventProducer,
     IEventConsumer,
     DomainEventMessage,
-    OutboundDomainEventMessageName,
     IKafkaEventConsumerOptions,
     IKafkaEventProducerOptions,
     ICommandEventProducer,
+    SDKOutboundBulkRequestReceivedMessage,
+    SDKOutboundBulkPartyInfoRequestedMessage,
 } from '@mojaloop/sdk-scheme-adapter-private-shared-lib';
 import { IDomainEventHandlerOptions } from '../types';
-import { handleSDKOutboundBulkRequestReceived } from './handlers';
+import { handleSDKOutboundBulkPartyInfoRequested, handleSDKOutboundBulkRequestReceived } from './handlers';
 
 export class OutboundEventHandler implements IRunHandler {
     private _logger: ILogger;
@@ -81,10 +82,14 @@ export class OutboundEventHandler implements IRunHandler {
 
     async _messageHandler(message: DomainEventMessage): Promise<void> {
         this._logger.info(`Got domain event message: ${message.getName()}`);
-        // TODO: Handle errros validation here
+        // TODO: Handle errors validation here
         switch (message.getName()) {
-            case OutboundDomainEventMessageName.SDKOutboundBulkRequestReceived: {
+            case SDKOutboundBulkRequestReceivedMessage.name: {
                 await handleSDKOutboundBulkRequestReceived(message, this._domainEventHandlerOptions, this._logger);
+                break;
+            }
+            case SDKOutboundBulkPartyInfoRequestedMessage.name: {
+                await handleSDKOutboundBulkPartyInfoRequested(message, this._domainEventHandlerOptions, this._logger);
                 break;
             }
             default: {

--- a/modules/outbound-domain-event-handler/src/application/handlers/index.ts
+++ b/modules/outbound-domain-event-handler/src/application/handlers/index.ts
@@ -23,3 +23,4 @@
  ******/
 
 export * from './sdk-outbound-bulk-request-received';
+export * from './sdk-outbound-bulk-party-info-requested';

--- a/modules/outbound-domain-event-handler/src/application/handlers/sdk-outbound-bulk-party-info-requested.ts
+++ b/modules/outbound-domain-event-handler/src/application/handlers/sdk-outbound-bulk-party-info-requested.ts
@@ -1,0 +1,60 @@
+/*****
+ License
+ --------------
+ Copyright © 2017 Bill & Melinda Gates Foundation
+ The Mojaloop files are made available by the Bill & Melinda Gates Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list (alphabetical ordering) of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+ * Modusbox
+ - Kevin leyow <kevin.leyow@modusbox.com>
+ --------------
+ ******/
+
+import { ILogger } from '@mojaloop/logging-bc-public-types-lib';
+import {
+    DomainEventMessage,
+    ProcessSDKOutboundBulkPartyInfoRequestMessage,
+    IProcessSDKOutboundBulkPartyInfoRequestMessageData,
+} from '@mojaloop/sdk-scheme-adapter-private-shared-lib';
+import { IDomainEventHandlerOptions } from '../../types';
+import { SDKOutboundBulkPartyInfoRequestedMessage } from '@mojaloop/sdk-scheme-adapter-private-shared-lib';
+
+export async function handleSDKOutboundBulkPartyInfoRequested(
+    message: DomainEventMessage,
+    options: IDomainEventHandlerOptions,
+    logger: ILogger,
+): Promise<void> {
+    const sdkOutboundBulkPartyInfoRequestedMessage
+        = SDKOutboundBulkPartyInfoRequestedMessage.CreateFromCommandEventMessage(message);
+
+    try {
+        const processSDKOutboundBulkPartyInfoRequestMessageData: IProcessSDKOutboundBulkPartyInfoRequestMessageData = {
+            bulkId: sdkOutboundBulkPartyInfoRequestedMessage.getKey(),
+            timestamp: Date.now(),
+            headers: sdkOutboundBulkPartyInfoRequestedMessage.getHeaders(),
+        };
+
+        const processSDKOutboundBulkPartyInfoRequestMessage
+            = new ProcessSDKOutboundBulkPartyInfoRequestMessage(processSDKOutboundBulkPartyInfoRequestMessageData);
+
+        await options.commandProducer.sendCommandMessage(processSDKOutboundBulkPartyInfoRequestMessage);
+
+        logger.info(`Sent command event ${processSDKOutboundBulkPartyInfoRequestMessage.getName()}`);
+        console.log(processSDKOutboundBulkPartyInfoRequestMessage);
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    } catch (err: any) {
+        logger.info(`Failed to create SDKOutboundBulkRequestEntity. ${err.message}`);
+    }
+}

--- a/modules/outbound-domain-event-handler/test/unit/application/handlers/sdk-outbound-bulk-party-info-requested.test.ts
+++ b/modules/outbound-domain-event-handler/test/unit/application/handlers/sdk-outbound-bulk-party-info-requested.test.ts
@@ -1,0 +1,79 @@
+/*****
+ License
+ --------------
+ Copyright © 2017 Bill & Melinda Gates Foundation
+ The Mojaloop files are made available by the Bill & Melinda Gates Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+ Contributors
+ --------------
+ This is the official list (alphabetical ordering) of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ * Modusbox
+ - Kevin Leyow <kevin.leyow@modusbox.com>
+
+ --------------
+ ******/
+
+'use strict'
+
+import { DefaultLogger } from "@mojaloop/logging-bc-client-lib";
+import { ILogger } from "@mojaloop/logging-bc-public-types-lib";
+import { DomainEventMessage, EventMessageType, IDomainEventMessageData, OutboundDomainEventMessageName, ProcessSDKOutboundBulkPartyInfoRequestMessage } from "@mojaloop/sdk-scheme-adapter-private-shared-lib"
+import { randomUUID } from "crypto";
+import { handleSDKOutboundBulkPartyInfoRequested } from "../../../../src/application/handlers"
+import { IDomainEventHandlerOptions } from "../../../../src/types";
+
+
+describe('handleSDKOutboundBulkPartyInfoRequested', () => {
+  const logger: ILogger = new DefaultLogger('bc', 'appName', 'appVersion');
+  const domainEventHandlerOptions = {
+    commandProducer: {
+      init: jest.fn(),
+      sendCommandMessage: jest.fn()
+    }
+  } as unknown as IDomainEventHandlerOptions
+
+  let sampleSDKOutboundBulkPartyInfoRequestedMessage: IDomainEventMessageData;
+  let uuid: string;
+
+  beforeEach(async () => {
+    uuid = randomUUID();
+    sampleSDKOutboundBulkPartyInfoRequestedMessage = {
+      key: uuid,
+      name: OutboundDomainEventMessageName.SDKOutboundBulkPartyInfoRequested,
+      content: {},
+      timestamp: Date.now(),
+      headers: [],
+    }
+  });
+
+
+  test('emits a processSDKOutboundBulkPartyInfoRequestMessage message', async () => {
+    const sampleDomainEventMessageDataObj = new DomainEventMessage(sampleSDKOutboundBulkPartyInfoRequestedMessage);
+    handleSDKOutboundBulkPartyInfoRequested(sampleDomainEventMessageDataObj, domainEventHandlerOptions, logger)
+    expect(domainEventHandlerOptions.commandProducer.sendCommandMessage)
+      .toBeCalledWith(
+        expect.objectContaining({
+          _data: expect.objectContaining({
+            key: uuid,
+            name: ProcessSDKOutboundBulkPartyInfoRequestMessage.name,
+            type: EventMessageType.COMMAND_EVENT
+          })
+        })
+    )
+  })
+})

--- a/modules/private-shared-lib/src/events/outbound_domain_event_message/index.ts
+++ b/modules/private-shared-lib/src/events/outbound_domain_event_message/index.ts
@@ -37,4 +37,4 @@ export enum OutboundDomainEventMessageName {
 export * from './party_info_requested';
 export * from './sdk_outbound_bulk_request_received';
 export * from './sdk_outbound_bulk_party_info_requested';
-export * from './party_info_callback_proceeded';
+export * from './party_info_callback_processed';

--- a/modules/private-shared-lib/src/events/outbound_domain_event_message/party_info_callback_processed.ts
+++ b/modules/private-shared-lib/src/events/outbound_domain_event_message/party_info_callback_processed.ts
@@ -27,7 +27,6 @@
 import { DomainEventMessage } from '../domain_event_message';
 import { IMessageHeader } from '@mojaloop/platform-shared-lib-messaging-types-lib';
 // import { v1_1 as FSPIOP } from '@mojaloop/api-snippets';
-import { OutboundDomainEventMessageName } from '.';
 
 export interface IPartyInfoCallbackProcessedMessageData {
     key: string;

--- a/modules/private-shared-lib/src/events/outbound_domain_event_message/party_info_callback_processed.ts
+++ b/modules/private-shared-lib/src/events/outbound_domain_event_message/party_info_callback_processed.ts
@@ -29,15 +29,15 @@ import { IMessageHeader } from '@mojaloop/platform-shared-lib-messaging-types-li
 // import { v1_1 as FSPIOP } from '@mojaloop/api-snippets';
 import { OutboundDomainEventMessageName } from '.';
 
-export interface IPartyInfoCallbackProceededMessageData {
+export interface IPartyInfoCallbackProcessedMessageData {
     key: string;
     // partyResult: FSPIOP.Schemas.PartyResult;
     timestamp: number | null;
     headers: IMessageHeader[] | null;
 }
 
-export class PartyInfoCallbackProceededMessage extends DomainEventMessage {
-    constructor(data: IPartyInfoCallbackProceededMessageData) {
+export class PartyInfoCallbackProcessedMessage extends DomainEventMessage {
+    constructor(data: IPartyInfoCallbackProcessedMessageData) {
         super({
             key: data.key,
             // content: data.partyResult,
@@ -56,16 +56,16 @@ export class PartyInfoCallbackProceededMessage extends DomainEventMessage {
         return this.getKey().split('_')[1];
     }
 
-    static CreateFromCommandEventMessage(message: DomainEventMessage): PartyInfoCallbackProceededMessage {
+    static CreateFromCommandEventMessage(message: DomainEventMessage): PartyInfoCallbackProcessedMessage {
         if((message.getContent() === null || typeof message.getContent() !== 'object')) {
             throw new Error('Content is in unknown format');
         }
-        const data: IPartyInfoCallbackProceededMessageData = {
+        const data: IPartyInfoCallbackProcessedMessageData = {
             key: message.getKey(),
             // partyResult: <FSPIOP.Schemas.PartyResult>message.getContent(),
             timestamp: message.getTimeStamp(),
             headers: message.getHeaders(),
         };
-        return new PartyInfoCallbackProceededMessage(data);
+        return new PartyInfoCallbackProcessedMessage(data);
     }
 }

--- a/modules/private-shared-lib/src/events/outbound_domain_event_message/party_info_callback_processed.ts
+++ b/modules/private-shared-lib/src/events/outbound_domain_event_message/party_info_callback_processed.ts
@@ -44,7 +44,7 @@ export class PartyInfoCallbackProcessedMessage extends DomainEventMessage {
             content: null,
             timestamp: data.timestamp,
             headers: data.headers,
-            name: OutboundDomainEventMessageName.PartyInfoCallbackProcessed,
+            name: PartyInfoCallbackProcessedMessage.name,
         });
     }
 

--- a/modules/private-shared-lib/src/events/outbound_domain_event_message/party_info_requested.ts
+++ b/modules/private-shared-lib/src/events/outbound_domain_event_message/party_info_requested.ts
@@ -44,7 +44,7 @@ export class PartyInfoRequestedMessage extends DomainEventMessage {
             content: data.request,
             timestamp: data.timestamp,
             headers: data.headers,
-            name: OutboundDomainEventMessageName.PartyInfoRequested,
+            name: PartyInfoRequestedMessage.name,
         });
     }
 

--- a/modules/private-shared-lib/src/events/outbound_domain_event_message/party_info_requested.ts
+++ b/modules/private-shared-lib/src/events/outbound_domain_event_message/party_info_requested.ts
@@ -26,7 +26,6 @@
 
 import { DomainEventMessage } from '../domain_event_message';
 import { IMessageHeader } from '@mojaloop/platform-shared-lib-messaging-types-lib';
-import { OutboundDomainEventMessageName } from '.';
 
 export interface IPartyInfoRequestedMessageData {
     bulkId: string;

--- a/modules/private-shared-lib/src/events/outbound_domain_event_message/sdk_outbound_bulk_party_info_requested.ts
+++ b/modules/private-shared-lib/src/events/outbound_domain_event_message/sdk_outbound_bulk_party_info_requested.ts
@@ -26,7 +26,6 @@
 
 import { DomainEventMessage } from '../domain_event_message';
 import { IMessageHeader } from '@mojaloop/platform-shared-lib-messaging-types-lib';
-import { OutboundDomainEventMessageName } from '.';
 
 export interface ISDKOutboundBulkPartyInfoRequestedMessageData {
     bulkId: string;

--- a/modules/private-shared-lib/src/events/outbound_domain_event_message/sdk_outbound_bulk_party_info_requested.ts
+++ b/modules/private-shared-lib/src/events/outbound_domain_event_message/sdk_outbound_bulk_party_info_requested.ts
@@ -41,7 +41,7 @@ export class SDKOutboundBulkPartyInfoRequestedMessage extends DomainEventMessage
             timestamp: data.timestamp,
             headers: data.headers,
             content: null,
-            name: OutboundDomainEventMessageName.SDKOutboundBulkPartyInfoRequested,
+            name: SDKOutboundBulkPartyInfoRequestedMessage.name,
         });
     }
 

--- a/modules/private-shared-lib/src/events/outbound_domain_event_message/sdk_outbound_bulk_request_received.ts
+++ b/modules/private-shared-lib/src/events/outbound_domain_event_message/sdk_outbound_bulk_request_received.ts
@@ -26,7 +26,6 @@
 
 import { DomainEventMessage } from '../domain_event_message';
 import { IMessageHeader } from '@mojaloop/platform-shared-lib-messaging-types-lib';
-import { OutboundDomainEventMessageName } from '.';
 import { SDKSchemeAdapter } from '@mojaloop/api-snippets';
 import { randomUUID } from 'crypto';
 

--- a/modules/private-shared-lib/src/events/outbound_domain_event_message/sdk_outbound_bulk_request_received.ts
+++ b/modules/private-shared-lib/src/events/outbound_domain_event_message/sdk_outbound_bulk_request_received.ts
@@ -46,8 +46,7 @@ export class SDKOutboundBulkRequestReceivedMessage extends DomainEventMessage {
             content: data.bulkRequest,
             timestamp: data.timestamp,
             headers: data.headers,
-            // TODO: Use the classname of the event instead of enum here
-            name: OutboundDomainEventMessageName.SDKOutboundBulkRequestReceived,
+            name: SDKOutboundBulkRequestReceivedMessage.name,
         });
     }
 


### PR DESCRIPTION
feat(mojaloop/#2883): add SDKOutboundBulkPartyInfoRequested handler - [https://github.com/mojaloop/project/issues/2883](https://github.com/mojaloop/project/issues/2883)

- Rename PartyInfoCallbackProceededMessage to PartyInfoCallbackProcessedMessage as outlined by https://github.com/mojaloop/sdk-scheme-adapter/blob/mvp/bulk-sdk/docs/design-bulk-transfers/outbound-sequence.md
- Add SDKOutboundBulkPartyInfoRequested domain event handler