### PR TITLE
fix(mojalop/3322): put transactionrequest and put transactionrequest error handlers

### DIFF
--- a/docker/ml-testing-toolkit/sample-tests/outbound-request-to-pay.json
+++ b/docker/ml-testing-toolkit/sample-tests/outbound-request-to-pay.json
@@ -1,8 +1,12 @@
 {
+  "name": "multi",
   "test_cases": [
     {
       "id": 1,
       "name": "Post Request To Pay",
+      "fileInfo": {
+        "path": "sample-tests/outbound-request-to-pay.json"
+      },
       "requests": [
         {
           "id": 1,
@@ -38,11 +42,35 @@
             "amount": "10",
             "transactionType": "TRANSFER"
           }
+        },
+        {
+          "id": 2,
+          "description": "Accept Party",
+          "apiVersion": {
+            "minorVersion": 0,
+            "majorVersion": 1,
+            "type": "scheme_adapter_outbound",
+            "prefix": "/sdk-out",
+            "hostnames": [],
+            "specFile": "spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml",
+            "callbackMapFile": "spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json",
+            "responseMapFile": "spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/response_map.json",
+            "jsfRefFile": "spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/mockRef.json",
+            "triggerTemplatesFolder": "spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/trigger_templates"
+          },
+          "operationPath": "/requestToPay/{requestToPayId}",
+          "path": "/requestToPay/{$prev.1.response.body.requestToPayId}",
+          "method": "put",
+          "params": {
+            "requestToPayId": "{$prev.1.response.body.requestToPayId}"
+          },
+          "url": "http://host.docker.internal:4001",
+          "body": {
+            "acceptParty": true
+          },
+          "disabled": false
         }
-      ],
-      "fileInfo": {
-        "path": "sample-tests/outbound-request-to-pay.json"
-      }
+      ]
     }
   ]
 }

--- a/docker/ml-testing-toolkit/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml
+++ b/docker/ml-testing-toolkit/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml
@@ -16,8 +16,8 @@ info:
     **Note on terminology:** The term "Switch" is equal to the term "Hub", and
     the term "FSP" is equal to the term "DFSP".
   license:
-    name: 'Apache License Version 2.0, January 2004'
-    url: 'http://www.apache.org/licenses/'
+    name: Apache License Version 2.0, January 2004
+    url: https://github.com/mojaloop/documentation/blob/master/LICENSE.md
   version: 1.0.0
 paths:
   /:
@@ -33,6 +33,411 @@ paths:
           description: >-
             Returns empty body if the scheme adapter outbound transfers service
             is running.
+  /accounts:
+    post:
+      summary: Create accounts on the Account Lookup Service
+      description: >-
+        The HTTP request `POST /accounts` is used to create account information
+        on the Account Lookup Service (ALS) regarding the provided list of
+        identities.
+
+
+        Caller DFSP is used as the account source FSP information
+      tags:
+        - Accounts
+      requestBody:
+        description: Identities list request body
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/accountsRequest'
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/accountsCreationCompleted'
+        '400':
+          $ref: '#/components/responses/accountsCreationError'
+        '500':
+          $ref: '#/components/responses/accountsCreationError'
+        '504':
+          $ref: '#/components/responses/accountsCreationTimeout'
+  /bulkQuotes:
+    post:
+      summary: Request bulk quotes for the provided financial transactions
+      description: >
+        The HTTP request `POST /bulkQuotes` is used to request a bulk quote to
+        fascilitate funds transfer from payer DFSP to payees' DFSP.
+      tags:
+        - BulkQuotes
+      requestBody:
+        description: Bulk quote request body
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/bulkQuoteRequest'
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/bulkQuoteSuccess'
+        '400':
+          $ref: '#/components/responses/bulkQuoteBadRequest'
+        '500':
+          $ref: '#/components/responses/bulkQuoteServerError'
+        '504':
+          $ref: '#/components/responses/bulkQuoteTimeout'
+  /bulkQuotes/{bulkQuoteId}:
+    get:
+      summary: Retrieves information for a specific bulk quote
+      description: >-
+        The HTTP request `GET /bulkQuotes/{bulktQuoteId}` is used to get
+        information regarding a bulk quote created or requested earlier. The
+        `{bulkQuoteId}` in the URI should contain the `bulkQuoteId` that was
+        used for the creation of the bulk quote.
+      tags:
+        - BulkQuotes
+      parameters:
+        - $ref: '#/components/parameters/bulkQuoteId'
+      responses:
+        '200':
+          description: Bulk quote information successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bulkQuoteStatusResponse'
+        '500':
+          description: An error occurred processing the bulk quote
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+  /bulkTransactions:
+    post:
+      summary: Sends money from one account to multiple accounts
+      description: >
+        The HTTP request `POST /bulkTransactions` is used to request the
+        movement of funds from payer DFSP to payees' DFSP.
+      tags:
+        - BulkTransactions
+      requestBody:
+        description: Bulk transfer request body
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/bulkTransactionRequest'
+        required: true
+      responses:
+        '202':
+          $ref: '#/components/responses/bulkTransactionAccepted'
+        '400':
+          $ref: '#/components/responses/bulkTransferBadRequest'
+        '500':
+          $ref: '#/components/responses/errorResponse'
+  /bulkTransactions/{bulkTransactionId}:
+    put:
+      summary: Amends the bulk transaction request
+      description: >-
+        The HTTP request `PUT /bulkTransactions/{bulkTransactionId}` is used to
+        amend information regarding a bulk transaction, i.e. when
+        autoAcceptParty or autoAcceptQuote  is false then the payer need to
+        provide confirmation to proceed with further processing of the request.
+        The `{bulkTransactionId}` in the URI should contain the
+        `bulkTransactionId` that was used for the creation of the bulk transfer.
+      tags:
+        - BulkTransactions
+      parameters:
+        - $ref: '#/components/parameters/bulkTransactionId'
+      requestBody:
+        description: Bulk transaction request body
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/bulkTransactionContinuationAcceptParty'
+                - $ref: '#/components/schemas/bulkTransactionContinuationAcceptQuote'
+        required: true
+      responses:
+        '202':
+          description: Bulk transaction information successfully amended
+        '400':
+          $ref: '#/components/responses/bulkTransactionPutBadRequest'
+        '500':
+          description: An error occurred processing the bulk transaction
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+  /bulkTransfers:
+    post:
+      summary: Sends money from one account to multiple accounts
+      description: >
+        The HTTP request `POST /bulkTransfers` is used to request the movement
+        of funds from payer DFSP to payees' DFSP.
+      tags:
+        - BulkTransfers
+      requestBody:
+        description: Bulk transfer request body
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/bulkTransferRequest'
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/bulkTransferSuccess'
+        '400':
+          $ref: '#/components/responses/bulkTransferBadRequest'
+        '500':
+          $ref: '#/components/responses/errorResponse'
+  /bulkTransfers/{bulkTransferId}:
+    get:
+      summary: Retrieves information for a specific bulk transfer
+      description: >-
+        The HTTP request `GET /bulkTransfers/{bulkTransferId}` is used to get
+        information regarding a bulk transfer created or requested earlier. The
+        `{bulkTransferId}` in the URI should contain the `bulkTransferId` that
+        was used for the creation of the bulk transfer.
+      tags:
+        - BulkTransfers
+      parameters:
+        - $ref: '#/components/parameters/bulkTransferId'
+      responses:
+        '200':
+          description: Bulk transfer information successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bulkTransferStatusResponse'
+        '500':
+          description: An error occurred processing the bulk transfer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+  /parties/{Type}/{ID}:
+    parameters:
+      - $ref: '#/components/parameters/Type'
+      - $ref: '#/components/parameters/ID'
+    get:
+      description: >-
+        The HTTP request GET /parties// (or GET /parties///) is used to lookup
+        information regarding the requested Party, defined by ,  and optionally
+        (for example, GET /parties/MSISDN/123456789, or GET
+        /parties/BUSINESS/shoecompany/employee1).
+      summary: PartiesByTypeAndID
+      tags:
+        - parties
+      operationId: PartiesByTypeAndID
+      responses:
+        '200':
+          $ref: '#/components/responses/partiesByIdSuccess'
+        '404':
+          $ref: '#/components/responses/partiesByIdError404'
+  /parties/{Type}/{ID}/{SubId}:
+    parameters:
+      - $ref: '#/components/parameters/Type'
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/SubId'
+    get:
+      description: >-
+        The HTTP request GET /parties// (or GET /parties///) is used to lookup
+        information regarding the requested Party, defined by ,  and optionally
+        (for example, GET /parties/MSISDN/123456789, or GET
+        /parties/BUSINESS/shoecompany/employee1).
+      summary: PartiesSubIdByTypeAndID
+      tags:
+        - parties
+      operationId: PartiesSubIdByTypeAndID
+      responses:
+        '200':
+          $ref: '#/components/responses/partiesByIdSuccess'
+        '404':
+          $ref: '#/components/responses/partiesByIdError404'
+  /quotes:
+    post:
+      summary: Quotes endpoint
+      description: is used to request quotes from other DFSP
+      tags:
+        - quotes
+      operationId: QuotesPost
+      requestBody:
+        description: Quotes request payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/simpleQuotesPostRequest'
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/quotesPostSuccess'
+        '500':
+          $ref: '#/components/responses/quotesServerError'
+  /requestToPay:
+    post:
+      summary: Receiver requesting funds from Sender
+      description: >
+        The HTTP request `POST /requestToPay` is used to support Pull Funds
+        pattern where in a receiver can request for funds from the Sender.
+
+        The underlying API has two stages:
+
+          1. Party lookup. This facilitates a check by the sending party that the destination party is correct before proceeding with a money movement.
+          2. Transaction Request. This request enables a Payee to request Payer to send electronic funds to the Payee.
+      tags:
+        - RequestToPay
+      requestBody:
+        description: RequestToPay request body
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/requestToPayRequest'
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/requestToPaySuccess'
+  /requestToPay/{requestToPayId}:
+    put:
+      summary: >-
+        Continues a request funds from sender that has paused at the party
+        resolution stage in order to accept or reject party information
+      description: >
+        The HTTP request `PUT /requestToPay/{requestToPayId}` is used to
+        continue a transfer initiated via the `POST /requestToPay` method that
+        has halted after party lookup stage.
+
+
+        The request body should contain the "acceptParty" property set to `true`
+        as required to continue the transfer.
+
+        See the description of the `POST /requestToPay` HTTP method for more
+        information on modes of transfer.
+      tags:
+        - RequestToPay
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/transferContinuationAcceptParty'
+      parameters:
+        - $ref: '#/components/parameters/requestToPayId'
+      responses:
+        '200':
+          $ref: '#/components/responses/requestToPaySuccess'
+        '500':
+          $ref: '#/components/responses/transferServerError'
+        '504':
+          $ref: '#/components/responses/transferTimeout'
+  /requestToPayTransfer:
+    post:
+      summary: >-
+        Used to trigger funds from customer fsp account to merchant fsp account.
+        This is a follow-up request to requestToPay.
+      description: >
+        The HTTP request `POST /requestToPayTransfer` is used to request the
+        movement of funds from payer DFSP to payee DFSP.
+
+        The underlying Mojaloop API has three stages for money transfer:
+
+          1. Quotation. This facilitates the exchange of fee information and the construction of a cryptographic "contract" between payee and payer DFSPs before funds are transferred.
+          2. Authorization. This facilitates getting OTP from payee DFSP.
+          3. Transfer. The enactment of the previously agreed "contract"
+
+        This method has several modes of operation.
+
+        - If the configuration variable `AUTO_ACCEPT_QUOTES` is set to `"false"`
+        this method will terminate and return the quotation when it has been
+        received from the payee DFSP.
+          If the payee wished to proceed with the otp, then a subsequent `PUT /transfers/{transferId}` request (accepting the quote) is required to continue the operation.
+          The scheme adapter will then proceed with the transfer state.
+
+        - If the configuration variable `AUTO_ACCEPT_OTP` is set to `"false"`
+        this method will terminate and return the otp when it has been received
+        from the payee DFSP.
+          If the payer wished to proceed with the transfer, then a subsequent `PUT /transfers/{transferId}` request (accepting the quote) is required to continue the operation.
+          The scheme adapter will then proceed with the transfer state.
+
+        If the configuration variables `AUTO_ACCEPT_PARTIES` and
+        `AUTO_ACCEPT_QUOTES` are both set to `"true"` this method will block
+        until all three transfer stages are complete. Upon completion it will
+        return the entire set of transfer details received during the operation.
+
+
+        Combinations of settings for `AUTO_ACCEPT...` configuration variables
+        allow the scheme adapter user to decide which mode of operation best
+        suits their use cases. i.e. the scheme adapter can be configured to
+        "break" the three stage transfer at these points in order to execute
+        backend logic such as party verification, quoted fees assessments etc...
+      tags:
+        - RequestToPayTransfer
+      requestBody:
+        description: Request To Pay Transfer request body
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/requestToPayTransferRequest'
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/requestToPayTransferSuccess'
+        '400':
+          $ref: '#/components/responses/requestToPayTransferBadRequest'
+        '500':
+          $ref: '#/components/responses/transferServerError'
+        '504':
+          $ref: '#/components/responses/transferTimeout'
+  /requestToPayTransfer/{requestToPayTransactionId}:
+    put:
+      summary: >-
+        Continues a transfer that has paused at the otp stage in order to accept
+        or reject quote
+      description: >
+        The HTTP request `PUT /transfers/{transferId}` is used to continue a
+        transfer initiated via the `POST /transfers` method that has halted
+        after party lookup and/or quotation stage.
+
+
+        The request body should contain either the "acceptOTP" or "acceptQuote"
+        property set to `true` as required to continue the transfer.
+
+
+        See the description of the `POST /requestToPayTransfer` HTTP method for
+        more information on modes of transfer.
+      tags:
+        - RequestToPayTransferID
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/transferContinuationAcceptQuote'
+                - $ref: '#/components/schemas/transferContinuationAcceptOTP'
+      parameters:
+        - $ref: '#/components/parameters/requestToPayTransactionId'
+      responses:
+        '200':
+          $ref: '#/components/responses/transferSuccess'
+        '500':
+          $ref: '#/components/responses/transferServerError'
+        '504':
+          $ref: '#/components/responses/transferTimeout'
+  /simpleTransfers:
+    post:
+      summary: Simple Transfers endpoint
+      description: is used to request a transfer
+      tags:
+        - transfers
+      operationId: SimpleTransfersPost
+      requestBody:
+        description: Simple Transfer request payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/simpleTransfersPostRequest'
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/simpleTransfersPostSuccess'
+        '500':
+          $ref: '#/components/responses/simpleTransfersServerError'
   /transfers:
     post:
       summary: Sends money from one account to another
@@ -89,7 +494,7 @@ paths:
           $ref: '#/components/responses/transferServerError'
         '504':
           $ref: '#/components/responses/transferTimeout'
-  '/transfers/{transferId}':
+  /transfers/{transferId}:
     put:
       summary: >-
         Continues a transfer that has paused at the quote stage in order to
@@ -149,362 +554,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/errorResponse'
-  /bulkTransfers:
-    post:
-      summary: Sends money from one account to multiple accounts
-      description: >
-        The HTTP request `POST /bulkTransfers` is used to request the movement
-        of funds from payer DFSP to payees' DFSP.
-      tags:
-        - BulkTransfers
-      requestBody:
-        description: Bulk transfer request body
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/bulkTransferRequest'
-        required: true
-      responses:
-        '200':
-          $ref: '#/components/responses/bulkTransferSuccess'
-        '400':
-          $ref: '#/components/responses/bulkTransferBadRequest'
-        '500':
-          $ref: '#/components/responses/bulkTransferServerError'
-        '504':
-          $ref: '#/components/responses/bulkTransferTimeout'
-  '/bulkTransfers/{bulkTransferId}':
-    get:
-      summary: Retrieves information for a specific bulk transfer
-      description: >-
-        The HTTP request `GET /bulkTransfers/{bulktTransferId}` is used to get
-        information regarding a bulk transfer created or requested earlier. The
-        `{bulkTransferId}` in the URI should contain the `bulkTransferId` that
-        was used for the creation of the bulk transfer.
-      tags:
-        - BulkTransfers
-      parameters:
-        - $ref: '#/components/parameters/bulkTransferId'
-      responses:
-        '200':
-          description: Bulk transfer information successfully retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/bulkTransferStatusResponse'
-        '500':
-          description: An error occurred processing the bulk transfer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorResponse'
-  /bulkQuotes:
-    post:
-      summary: Request bulk quotes for the provided financial transactions
-      description: >
-        The HTTP request `POST /bulkQuotes` is used to request a bulk quote to
-        fascilitate funds transfer from payer DFSP to payees' DFSP.
-      tags:
-        - BulkQuotes
-      requestBody:
-        description: Bulk quote request body
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/bulkQuoteRequest'
-        required: true
-      responses:
-        '200':
-          $ref: '#/components/responses/bulkQuoteSuccess'
-        '400':
-          $ref: '#/components/responses/bulkQuoteBadRequest'
-        '500':
-          $ref: '#/components/responses/bulkQuoteServerError'
-        '504':
-          $ref: '#/components/responses/bulkQuoteTimeout'
-  '/bulkQuotes/{bulkQuoteId}':
-    get:
-      summary: Retrieves information for a specific bulk quote
-      description: >-
-        The HTTP request `GET /bulkQuotes/{bulktQuoteId}` is used to get
-        information regarding a bulk quote created or requested earlier. The
-        `{bulkQuoteId}` in the URI should contain the `bulkQuoteId` that was
-        used for the creation of the bulk quote.
-      tags:
-        - BulkQuotes
-      parameters:
-        - $ref: '#/components/parameters/bulkQuoteId'
-      responses:
-        '200':
-          description: Bulk quote information successfully retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/bulkQuoteStatusResponse'
-        '500':
-          description: An error occurred processing the bulk quote
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorResponse'
-  /requestToPay:
-    post:
-      summary: Receiver requesting funds from Sender
-      description: >
-        The HTTP request `POST /requestToPay` is used to support Pull Funds
-        pattern where in a receiver can request for funds from the Sender.
-
-        The underlying API has two stages:
-
-          1. Party lookup. This facilitates a check by the sending party that the destination party is correct before proceeding with a money movement.
-          2. Transaction Request. This request enables a Payee to request Payer to send electronic funds to the Payee.
-      tags:
-        - RequestToPay
-      requestBody:
-        description: RequestToPay request body
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/requestToPayRequest'
-        required: true
-      responses:
-        '200':
-          $ref: '#/components/responses/requestToPaySuccess'
-  /requestToPayTransfer:
-    post:
-      summary: >-
-        Used to trigger funds from customer fsp account to merchant fsp account.
-        This is a follow-up request to requestToPay.
-      description: >
-        The HTTP request `POST /requestToPayTransfer` is used to request the
-        movement of funds from payer DFSP to payee DFSP.
-
-        The underlying Mojaloop API has three stages for money transfer:
-
-          1. Quotation. This facilitates the exchange of fee information and the construction of a cryptographic "contract" between payee and payer DFSPs before funds are transferred.
-          2. Authorization. This facilitates getting OTP from payee DFSP.
-          3. Transfer. The enactment of the previously agreed "contract"
-
-        This method has several modes of operation.
-
-        - If the configuration variable `AUTO_ACCEPT_QUOTES` is set to `"false"`
-        this method will terminate and return the quotation when it has been
-        received from the payee DFSP.
-          If the payee wished to proceed with the otp, then a subsequent `PUT /transfers/{transferId}` request (accepting the quote) is required to continue the operation.
-          The scheme adapter will then proceed with the transfer state.
-
-        - If the configuration variable `AUTO_ACCEPT_OTP` is set to `"false"`
-        this method will terminate and return the otp when it has been received
-        from the payee DFSP.
-          If the payer wished to proceed with the transfer, then a subsequent `PUT /transfers/{transferId}` request (accepting the quote) is required to continue the operation.
-          The scheme adapter will then proceed with the transfer state.
-
-        If the configuration variables `AUTO_ACCEPT_PARTIES` and
-        `AUTO_ACCEPT_QUOTES` are both set to `"true"` this method will block
-        until all three transfer stages are complete. Upon completion it will
-        return the entire set of transfer details received during the operation.
-
-
-        Combinations of settings for `AUTO_ACCEPT...` configuration variables
-        allow the scheme adapter user to decide which mode of operation best
-        suits their use cases. i.e. the scheme adapter can be configured to
-        "break" the three stage transfer at these points in order to execute
-        backend logic such as party verification, quoted fees assessments etc...
-      tags:
-        - RequestToPayTransfer
-      requestBody:
-        description: Request To Pay Transfer request body
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/requestToPayTransferRequest'
-        required: true
-      responses:
-        '200':
-          $ref: '#/components/responses/requestToPayTransferSuccess'
-        '400':
-          $ref: '#/components/responses/requestToPayTransferBadRequest'
-        '500':
-          $ref: '#/components/responses/transferServerError'
-        '504':
-          $ref: '#/components/responses/transferTimeout'
-  '/requestToPayTransfer/{requestToPayTransactionId}':
-    put:
-      summary: >-
-        Continues a transfer that has paused at the otp stage in order to accept
-        or reject quote
-      description: >
-        The HTTP request `PUT /transfers/{transferId}` is used to continue a
-        transfer initiated via the `POST /transfers` method that has halted
-        after party lookup and/or quotation stage.
-
-
-        The request body should contain either the "acceptOTP" or "acceptQuote"
-        property set to `true` as required to continue the transfer.
-
-
-        See the description of the `POST /requestToPayTransfer` HTTP method for
-        more information on modes of transfer.
-      tags:
-        - RequestToPayTransferID
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-                - $ref: '#/components/schemas/transferContinuationAcceptQuote'
-                - $ref: '#/components/schemas/transferContinuationAcceptOTP'
-      parameters:
-        - $ref: '#/components/parameters/requestToPayTransactionId'
-      responses:
-        '200':
-          $ref: '#/components/responses/transferSuccess'
-        '500':
-          $ref: '#/components/responses/transferServerError'
-        '504':
-          $ref: '#/components/responses/transferTimeout'
-  /accounts:
-    post:
-      summary: Create accounts on the Account Lookup Service
-      description: >-
-        The HTTP request `POST /accounts` is used to create account information
-        on the Account Lookup Service (ALS) regarding the provided list of
-        identities.
-
-
-        Caller DFSP is used as the account source FSP information
-      tags:
-        - Accounts
-      requestBody:
-        description: Identities list request body
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/accountsRequest'
-        required: true
-      responses:
-        '200':
-          $ref: '#/components/responses/accountsCreationCompleted'
-        '400':
-          $ref: '#/components/responses/accountsCreationError'
-        '500':
-          $ref: '#/components/responses/accountsCreationError'
-        '504':
-          $ref: '#/components/responses/accountsCreationTimeout'
-  '/parties/{Type}/{ID}':
-    parameters:
-      - $ref: '#/components/parameters/Type'
-      - $ref: '#/components/parameters/ID'
-    get:
-      description: >-
-        The HTTP request GET /parties// (or GET /parties///) is used to lookup
-        information regarding the requested Party, defined by ,  and optionally
-        (for example, GET /parties/MSISDN/123456789, or GET
-        /parties/BUSINESS/shoecompany/employee1).
-      summary: PartiesByTypeAndID
-      tags:
-        - parties
-      operationId: PartiesByTypeAndID
-      responses:
-        '200':
-          $ref: '#/components/responses/partiesByIdSuccess'
-        '404':
-          $ref: '#/components/responses/partiesByIdError404'
-  '/parties/{Type}/{ID}/{SubId}':
-    parameters:
-      - $ref: '#/components/parameters/Type'
-      - $ref: '#/components/parameters/ID'
-      - $ref: '#/components/parameters/SubId'
-    get:
-      description: >-
-        The HTTP request GET /parties// (or GET /parties///) is used to lookup
-        information regarding the requested Party, defined by ,  and optionally
-        (for example, GET /parties/MSISDN/123456789, or GET
-        /parties/BUSINESS/shoecompany/employee1).
-      summary: PartiesSubIdByTypeAndID
-      tags:
-        - parties
-      operationId: PartiesSubIdByTypeAndID
-      responses:
-        '200':
-          $ref: '#/components/responses/partiesByIdSuccess'
-        '404':
-          $ref: '#/components/responses/partiesByIdError404'
-  /quotes:
-    post:
-      summary: Quotes endpoint
-      description: is used to request quotes from other DFSP
-      tags:
-        - quotes
-      operationId: QuotesPost
-      requestBody:
-        description: Quotes request payload
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/quotesPostRequest'
-        required: true
-      responses:
-        '200':
-          $ref: '#/components/responses/quotesPostSuccess'
-        '500':
-          $ref: '#/components/responses/quotesServerError'
-  /simpleTransfers:
-    post:
-      summary: Simple Transfers endpoint
-      description: is used to request a transfer
-      tags:
-        - transfers
-      operationId: SimpleTransfersPost
-      requestBody:
-        description: Simple Transfer request payload
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/simpleTransfersPostRequest'
-        required: true
-      responses:
-        '200':
-          $ref: '#/components/responses/simpleTransfersPostSuccess'
-        '500':
-          $ref: '#/components/responses/simpleTransfersServerError'
-  /authorizations:
-    post:
-      description: >-
-        The HTTP request `POST /authorizations` is used to request the Payer to
-        enter the applicable credentials in the PISP system.
-      summary: Authorizations endpoint
-      operationId: AuthorizationsPost
-      tags:
-        - authorizations
-      requestBody:
-        description: Perform authorization
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/authorizationsPostRequest'
-      responses:
-        '200':
-          $ref: '#/components/responses/authorizationPostSuccess'
-        '500':
-          $ref: '#/components/responses/authorizationsServerError'
 components:
   schemas:
-    TransactionInitiatorType:
-      title: TransactionInitiatorType
-      type: string
-      enum:
-        - CONSUMER
-        - AGENT
-        - BUSINESS
-        - DEVICE
-      description: |-
-        Below are the allowed values for the enumeration.
-        - CONSUMER - Consumer is the initiator of the transaction.
-        - AGENT - Agent is the initiator of the transaction.
-        - BUSINESS - Business is the initiator of the transaction.
-        - DEVICE - Device is the initiator of the transaction.
     PartyIdType:
       title: PartyIdType
       type: string
@@ -517,111 +568,59 @@ components:
         - ACCOUNT_ID
         - IBAN
         - ALIAS
-        - CONSENT
-        - THIRD_PARTY_LINK
-      description: >
-        This is a variant based on FSPIOP `PartyIdType` specification.
-
-        Main difference being the CONSENT and THIRD_PARTY_LINK enums.
-
-
+      description: >-
         Below are the allowed values for the enumeration.
 
         - MSISDN - An MSISDN (Mobile Station International Subscriber Directory
-
         Number, that is, the phone number) is used as reference to a
-        participant.
-
-        The MSISDN identifier should be in international format according to the
-
-        [ITU-T E.164 standard](https://www.itu.int/rec/T-REC-E.164/en).
-
-        Optionally, the MSISDN may be prefixed by a single plus sign, indicating
-        the
-
+        participant. The MSISDN identifier should be in international format
+        according to the [ITU-T E.164
+        standard](https://www.itu.int/rec/T-REC-E.164/en). Optionally, the
+        MSISDN may be prefixed by a single plus sign, indicating the
         international prefix.
 
-        - EMAIL - An email is used as reference to a
-
-        participant. The format of the email should be according to the
-        informational
-
-        [RFC 3696](https://tools.ietf.org/html/rfc3696).
+        - EMAIL - An email is used as reference to a participant. The format of
+        the email should be according to the informational [RFC
+        3696](https://tools.ietf.org/html/rfc3696).
 
         - PERSONAL_ID - A personal identifier is used as reference to a
-        participant.
-
-        Examples of personal identification are passport number, birth
-        certificate
-
-        number, and national registration number. The identifier number is added
-        in
-
-        the PartyIdentifier element. The personal identifier type is added in
-        the
-
-        PartySubIdOrType element.
+        participant. Examples of personal identification are passport number,
+        birth certificate number, and national registration number. The
+        identifier number is added in the PartyIdentifier element. The personal
+        identifier type is added in the PartySubIdOrType element.
 
         - BUSINESS - A specific Business (for example, an organization or a
-        company)
-
-        is used as reference to a participant. The BUSINESS identifier can be in
-        any
-
-        format. To make a transaction connected to a specific username or bill
-        number
-
-        in a Business, the PartySubIdOrType element should be used.
+        company) is used as reference to a participant. The BUSINESS identifier
+        can be in any format. To make a transaction connected to a specific
+        username or bill number in a Business, the PartySubIdOrType element
+        should be used.
 
         - DEVICE - A specific device (for example, a POS or ATM) ID connected to
-        a
-
-        specific business or organization is used as reference to a Party.
-
-        For referencing a specific device under a specific business or
-        organization,
-
+        a specific business or organization is used as reference to a Party. For
+        referencing a specific device under a specific business or organization,
         use the PartySubIdOrType element.
 
         - ACCOUNT_ID - A bank account number or FSP account ID should be used as
-
         reference to a participant. The ACCOUNT_ID identifier can be in any
-        format,
-
-        as formats can greatly differ depending on country and FSP.
+        format, as formats can greatly differ depending on country and FSP.
 
         - IBAN - A bank account number or FSP account ID is used as reference to
-        a
-
-        participant. The IBAN identifier can consist of up to 34 alphanumeric
-
+        a participant. The IBAN identifier can consist of up to 34 alphanumeric
         characters and should be entered without whitespace.
 
         - ALIAS An alias is used as reference to a participant. The alias should
-        be
-
-        created in the FSP as an alternative reference to an account owner.
-
-        Another example of an alias is a username in the FSP system.
-
-        The ALIAS identifier can be in any format. It is also possible to use
-        the
-
+        be created in the FSP as an alternative reference to an account owner.
+        Another example of an alias is a username in the FSP system. The ALIAS
+        identifier can be in any format. It is also possible to use the
         PartySubIdOrType element for identifying an account under an Alias
-        defined
-
-        by the PartyIdentifier.
-
-        - CONSENT - TBD
-
-        - THIRD_PARTY_LINK - TBD
-      example: PERSONAL_ID
+        defined by the PartyIdentifier.
     PartyIdentifier:
       title: PartyIdentifier
       type: string
       minLength: 1
       maxLength: 128
       description: Identifier of the Party.
+      example: '16135551212'
     PartySubIdOrType:
       title: PartySubIdOrType
       type: string
@@ -630,140 +629,6 @@ components:
       description: >-
         Either a sub-identifier of a PartyIdentifier, or a sub-type of the
         PartyIdType, normally a PersonalIdentifierType.
-    Name:
-      title: Name
-      type: string
-      pattern: '^(?!\s*$)[\w .,''-]{1,128}$'
-      description: >-
-        The API data type Name is a JSON String, restricted by a regular
-        expression to avoid characters which are generally not used in a name.
-
-
-        Regular Expression - The regular expression for restricting the Name
-        type is "^(?!\s*$)[\w .,'-]{1,128}$". The restriction does not allow a
-        string consisting of whitespace only, all Unicode characters are
-        allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,)
-        and space characters ( ).
-
-
-        **Note:** In some programming languages, Unicode support must be
-        specifically enabled. For example, if Java is used, the flag
-        UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.
-    FirstName:
-      title: FirstName
-      type: string
-      minLength: 1
-      maxLength: 128
-      pattern: '^(?!\s*$)[\w .,''-]{1,128}$'
-      description: First name of the Party (Name Type).
-    MiddleName:
-      title: MiddleName
-      type: string
-      minLength: 1
-      maxLength: 128
-      pattern: '^(?!\s*$)[\w .,''-]{1,128}$'
-      description: Middle name of the Party (Name Type).
-    LastName:
-      title: LastName
-      type: string
-      minLength: 1
-      maxLength: 128
-      pattern: '^(?!\s*$)[\w .,''-]{1,128}$'
-      description: Last name of the Party (Name Type).
-    DateOfBirth:
-      title: DateofBirth (type Date)
-      type: string
-      pattern: >-
-        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
-      description: Date of Birth of the Party.
-    MerchantClassificationCode:
-      title: MerchantClassificationCode
-      type: string
-      pattern: '^[\d]{1,4}$'
-      description: >-
-        A limited set of pre-defined numbers. This list would be a limited set
-        of numbers identifying a set of popular merchant types like School Fees,
-        Pubs and Restaurants, Groceries, etc.
-    FspId:
-      title: FspId
-      type: string
-      minLength: 1
-      maxLength: 32
-      description: FSP identifier.
-    ExtensionKey:
-      title: ExtensionKey
-      type: string
-      minLength: 1
-      maxLength: 32
-      description: Extension key.
-    ExtensionValue:
-      title: ExtensionValue
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Extension value.
-    Extension:
-      title: Extension
-      type: object
-      description: Data model for the complex type Extension.
-      properties:
-        key:
-          $ref: '#/components/schemas/ExtensionKey'
-        value:
-          $ref: '#/components/schemas/ExtensionValue'
-      required:
-        - key
-        - value
-    extensionListEmptiable:
-      type: array
-      items:
-        $ref: '#/components/schemas/Extension'
-      minItems: 0
-      maxItems: 16
-    transferParty:
-      type: object
-      required:
-        - idType
-        - idValue
-      properties:
-        type:
-          $ref: '#/components/schemas/TransactionInitiatorType'
-        idType:
-          $ref: '#/components/schemas/PartyIdType'
-        idValue:
-          $ref: '#/components/schemas/PartyIdentifier'
-        idSubValue:
-          $ref: '#/components/schemas/PartySubIdOrType'
-        displayName:
-          $ref: '#/components/schemas/Name'
-        firstName:
-          $ref: '#/components/schemas/FirstName'
-        middleName:
-          $ref: '#/components/schemas/MiddleName'
-        lastName:
-          $ref: '#/components/schemas/LastName'
-        dateOfBirth:
-          $ref: '#/components/schemas/DateOfBirth'
-        merchantClassificationCode:
-          $ref: '#/components/schemas/MerchantClassificationCode'
-        fspId:
-          $ref: '#/components/schemas/FspId'
-        extensionList:
-          $ref: '#/components/schemas/extensionListEmptiable'
-    AmountType:
-      title: AmountType
-      type: string
-      enum:
-        - SEND
-        - RECEIVE
-      description: >-
-        Below are the allowed values for the enumeration AmountType.
-
-        - SEND - Amount the Payer would like to send, that is, the amount that
-        should be withdrawn from the Payer account including any fees.
-
-        - RECEIVE - Amount the Payer would like the Payee to receive, that is,
-        the amount that should be sent to the receiver exclusive of any fees.
     Currency:
       title: Currency
       description: >-
@@ -939,62 +804,23 @@ components:
         - ZAR
         - ZMW
         - ZWD
-    Amount:
-      title: Amount
-      type: string
-      pattern: '^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$'
-      description: >-
-        The API data type Amount is a JSON String in a canonical format that is
-        restricted by a regular expression for interoperability reasons. This
-        pattern does not allow any trailing zeroes at all, but allows an amount
-        without a minor currency unit. It also only allows four digits in the
-        minor currency unit; a negative value is not allowed. Using more than 18
-        digits in the major currency unit is not allowed.
-    transactionType:
-      type: string
-      enum:
-        - TRANSFER
-      description: Type of transaction.
-    Note:
-      title: Note
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Memo assigned to transaction.
-    transferRequest:
-      type: object
-      required:
-        - homeTransactionId
-        - from
-        - to
-        - amountType
-        - currency
-        - amount
-        - transactionType
-      properties:
-        homeTransactionId:
-          type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
-        from:
-          $ref: '#/components/schemas/transferParty'
-        to:
-          $ref: '#/components/schemas/transferParty'
-        amountType:
-          $ref: '#/components/schemas/AmountType'
-        currency:
-          $ref: '#/components/schemas/Currency'
-        amount:
-          $ref: '#/components/schemas/Amount'
-        transactionType:
-          $ref: '#/components/schemas/transactionType'
-        note:
-          $ref: '#/components/schemas/Note'
-        quoteRequestExtensions:
-          $ref: '#/components/schemas/extensionListEmptiable'
-        transferRequestExtensions:
-          $ref: '#/components/schemas/extensionListEmptiable'
+    accountsRequest:
+      type: array
+      items:
+        type: object
+        required:
+          - idType
+          - idValue
+          - currency
+        properties:
+          idType:
+            $ref: '#/components/schemas/PartyIdType'
+          idValue:
+            $ref: '#/components/schemas/PartyIdentifier'
+          idSubValue:
+            $ref: '#/components/schemas/PartySubIdOrType'
+          currency:
+            $ref: '#/components/schemas/Currency'
     CorrelationId:
       title: CorrelationId
       type: string
@@ -1007,82 +833,80 @@ components:
         4122](https://tools.ietf.org/html/rfc4122), that is restricted by a
         regular expression for interoperability reasons. A UUID is always 36
         characters long, 32 hexadecimal symbols and 4 dashes (‘-‘).
-    transferStatus:
+      example: b51ec534-ee48-4575-b6a9-ead2955b8069
+    errorResponse:
+      type: object
+      properties:
+        statusCode:
+          type: string
+          description: Error code as string.
+        message:
+          type: string
+          description: Error message text.
+    accountCreationStatus:
+      type: array
+      items:
+        type: object
+        required:
+          - idType
+          - idValue
+        properties:
+          idType:
+            $ref: '#/components/schemas/PartyIdType'
+          idValue:
+            $ref: '#/components/schemas/PartyIdentifier'
+          idSubValue:
+            $ref: '#/components/schemas/PartySubIdOrType'
+          error:
+            $ref: '#/components/schemas/errorResponse'
+    accountsCreationState:
       type: string
       enum:
         - ERROR_OCCURRED
-        - WAITING_FOR_PARTY_ACCEPTANCE
-        - WAITING_FOR_QUOTE_ACCEPTANCE
         - COMPLETED
-    Money:
-      title: Money
-      type: object
-      description: Data model for the complex type Money.
-      properties:
-        currency:
-          $ref: '#/components/schemas/Currency'
-        amount:
-          $ref: '#/components/schemas/Amount'
-      required:
-        - currency
-        - amount
-    DateTime:
-      title: DateTime
+    ErrorCode:
+      title: ErrorCode
       type: string
-      pattern: >-
-        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
+      pattern: ^[1-9]\d{3}$
       description: >-
-        The API data type DateTime is a JSON String in a lexical format that is
-        restricted by a regular expression for interoperability reasons. The
-        format is according to [ISO
-        8601](https://www.iso.org/iso-8601-date-and-time-format.html), expressed
-        in a combined date, time and time zone format. A more readable version
-        of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples are
-        "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z
-        indicates Zulu time zone, same as UTC).
-    Latitude:
-      title: Latitude
+        The API data type ErrorCode is a JSON String of four characters,
+        consisting of digits only. Negative numbers are not allowed. A leading
+        zero is not allowed. Each error code in the API is a four-digit number,
+        for example, 1234, where the first number (1 in the example) represents
+        the high-level error category, the second number (2 in the example)
+        represents the low-level error category, and the last two numbers (34 in
+        the example) represent the specific error.
+      example: '5100'
+    ErrorDescription:
+      title: ErrorDescription
       type: string
-      pattern: >-
-        ^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$
-      description: >-
-        The API data type Latitude is a JSON String in a lexical format that is
-        restricted by a regular expression for interoperability reasons.
-    Longitude:
-      title: Longitude
-      type: string
-      pattern: >-
-        ^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$
-      description: >-
-        The API data type Longitude is a JSON String in a lexical format that is
-        restricted by a regular expression for interoperability reasons.
-    GeoCode:
-      title: GeoCode
-      type: object
-      description: >-
-        Data model for the complex type GeoCode. Indicates the geographic
-        location from where the transaction was initiated.
-      properties:
-        latitude:
-          $ref: '#/components/schemas/Latitude'
-        longitude:
-          $ref: '#/components/schemas/Longitude'
-      required:
-        - latitude
-        - longitude
-    IlpPacket:
-      title: IlpPacket
-      type: string
-      pattern: '^[A-Za-z0-9-_]+[=]{0,2}$'
       minLength: 1
-      maxLength: 32768
-      description: Information for recipient (transport layer information).
-    IlpCondition:
-      title: IlpCondition
+      maxLength: 128
+      description: Error description string.
+    ExtensionKey:
+      title: ExtensionKey
       type: string
-      pattern: '^[A-Za-z0-9-_]{43}$'
-      maxLength: 48
-      description: Condition that must be attached to the transfer by the Payer.
+      minLength: 1
+      maxLength: 32
+      description: Extension key.
+    ExtensionValue:
+      title: ExtensionValue
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Extension value.
+    Extension:
+      title: Extension
+      type: object
+      description: Data model for the complex type Extension.
+      properties:
+        key:
+          $ref: '#/components/schemas/ExtensionKey'
+        value:
+          $ref: '#/components/schemas/ExtensionValue'
+      required:
+        - key
+        - value
     ExtensionList:
       title: ExtensionList
       type: object
@@ -1099,92 +923,6 @@ components:
           description: Number of Extension elements.
       required:
         - extension
-    QuotesIDPutResponse:
-      title: QuotesIDPutResponse
-      type: object
-      description: 'The object sent in the PUT /quotes/{ID} callback.'
-      properties:
-        transferAmount:
-          $ref: '#/components/schemas/Money'
-        payeeReceiveAmount:
-          $ref: '#/components/schemas/Money'
-        payeeFspFee:
-          $ref: '#/components/schemas/Money'
-        payeeFspCommission:
-          $ref: '#/components/schemas/Money'
-        expiration:
-          $ref: '#/components/schemas/DateTime'
-        geoCode:
-          $ref: '#/components/schemas/GeoCode'
-        ilpPacket:
-          $ref: '#/components/schemas/IlpPacket'
-        condition:
-          $ref: '#/components/schemas/IlpCondition'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - transferAmount
-        - expiration
-        - ilpPacket
-        - condition
-    IlpFulfilment:
-      title: IlpFulfilment
-      type: string
-      pattern: '^[A-Za-z0-9-_]{43}$'
-      maxLength: 48
-      description: Fulfilment that must be attached to the transfer by the Payee.
-    TransferState:
-      title: TransferState
-      type: string
-      enum:
-        - RECEIVED
-        - RESERVED
-        - COMMITTED
-        - ABORTED
-      description: >-
-        Below are the allowed values for the enumeration.
-
-        - RECEIVED - Next ledger has received the transfer.
-
-        - RESERVED - Next ledger has reserved the transfer.
-
-        - COMMITTED - Next ledger has successfully performed the transfer.
-
-        - ABORTED - Next ledger has aborted the transfer due to a rejection or
-        failure to perform the transfer.
-    TransfersIDPutResponse:
-      title: TransfersIDPutResponse
-      type: object
-      description: 'The object sent in the PUT /transfers/{ID} callback.'
-      properties:
-        fulfilment:
-          $ref: '#/components/schemas/IlpFulfilment'
-        completedTimestamp:
-          $ref: '#/components/schemas/DateTime'
-        transferState:
-          $ref: '#/components/schemas/TransferState'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - transferState
-    ErrorCode:
-      title: ErrorCode
-      type: string
-      pattern: '^[1-9]\d{3}$'
-      description: >-
-        The API data type ErrorCode is a JSON String of four characters,
-        consisting of digits only. Negative numbers are not allowed. A leading
-        zero is not allowed. Each error code in the API is a four-digit number,
-        for example, 1234, where the first number (1 in the example) represents
-        the high-level error category, the second number (2 in the example)
-        represents the low-level error category, and the last two numbers (34 in
-        the example) represent the specific error.
-    ErrorDescription:
-      title: ErrorDescription
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Error description string.
     ErrorInformation:
       title: ErrorInformation
       type: object
@@ -1217,26 +955,215 @@ components:
             actual HTTP status code returned with the response.
         mojaloopError:
           $ref: '#/components/schemas/mojaloopError'
-    transferResponse:
+    accountsResponse:
       type: object
       required:
-        - homeTransactionId
-        - from
-        - to
-        - amountType
-        - currency
-        - amount
-        - transactionType
+        - accounts
       properties:
-        transferId:
+        modelId:
           $ref: '#/components/schemas/CorrelationId'
-        homeTransactionId:
-          type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
-        from:
-          $ref: '#/components/schemas/transferParty'
+        accounts:
+          $ref: '#/components/schemas/accountsRequest'
+        response:
+          $ref: '#/components/schemas/accountCreationStatus'
+        currentState:
+          $ref: '#/components/schemas/accountsCreationState'
+        lastError:
+          $ref: '#/components/schemas/transferError'
+        postAccountsResponse:
+          type: object
+          required:
+            - body
+          properties:
+            body:
+              type: object
+            headers:
+              type: object
+    errorAccountsResponse:
+      allOf:
+        - $ref: '#/components/schemas/errorResponse'
+        - type: object
+          required:
+            - executionState
+          properties:
+            executionState:
+              $ref: '#/components/schemas/accountsResponse'
+    TransactionInitiatorType:
+      title: TransactionInitiatorType
+      type: string
+      enum:
+        - CONSUMER
+        - AGENT
+        - BUSINESS
+        - DEVICE
+      description: |-
+        Below are the allowed values for the enumeration.
+        - CONSUMER - Consumer is the initiator of the transaction.
+        - AGENT - Agent is the initiator of the transaction.
+        - BUSINESS - Business is the initiator of the transaction.
+        - DEVICE - Device is the initiator of the transaction.
+      example: CONSUMER
+    Name:
+      title: Name
+      type: string
+      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+      description: >-
+        The API data type Name is a JSON String, restricted by a regular
+        expression to avoid characters which are generally not used in a name.
+
+
+        Regular Expression - The regular expression for restricting the Name
+        type is "^(?!\s*$)[\w .,'-]{1,128}$". The restriction does not allow a
+        string consisting of whitespace only, all Unicode characters are
+        allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,)
+        and space characters ( ).
+
+
+        **Note:** In some programming languages, Unicode support must be
+        specifically enabled. For example, if Java is used, the flag
+        UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.
+    FirstName:
+      title: FirstName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: >-
+        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
+        .,''-]{1,128}$
+      description: First name of the Party (Name Type).
+      example: Henrik
+    MiddleName:
+      title: MiddleName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: >-
+        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
+        .,''-]{1,128}$
+      description: Middle name of the Party (Name Type).
+      example: Johannes
+    LastName:
+      title: LastName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: >-
+        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
+        .,''-]{1,128}$
+      description: Last name of the Party (Name Type).
+      example: Karlsson
+    DateOfBirth:
+      title: DateofBirth (type Date)
+      type: string
+      pattern: >-
+        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
+      description: Date of Birth of the Party.
+      example: '1966-06-16'
+    MerchantClassificationCode:
+      title: MerchantClassificationCode
+      type: string
+      pattern: ^[\d]{1,4}$
+      description: >-
+        A limited set of pre-defined numbers. This list would be a limited set
+        of numbers identifying a set of popular merchant types like School Fees,
+        Pubs and Restaurants, Groceries, etc.
+    FspId:
+      title: FspId
+      type: string
+      minLength: 1
+      maxLength: 32
+      description: FSP identifier.
+    extensionListEmptiable:
+      type: array
+      items:
+        $ref: '#/components/schemas/Extension'
+      minItems: 0
+      maxItems: 16
+    transferParty:
+      type: object
+      required:
+        - idType
+        - idValue
+      properties:
+        type:
+          $ref: '#/components/schemas/TransactionInitiatorType'
+        idType:
+          $ref: '#/components/schemas/PartyIdType'
+        idValue:
+          $ref: '#/components/schemas/PartyIdentifier'
+        idSubValue:
+          $ref: '#/components/schemas/PartySubIdOrType'
+        displayName:
+          $ref: '#/components/schemas/Name'
+        firstName:
+          $ref: '#/components/schemas/FirstName'
+        middleName:
+          $ref: '#/components/schemas/MiddleName'
+        lastName:
+          $ref: '#/components/schemas/LastName'
+        dateOfBirth:
+          $ref: '#/components/schemas/DateOfBirth'
+        merchantClassificationCode:
+          $ref: '#/components/schemas/MerchantClassificationCode'
+        fspId:
+          $ref: '#/components/schemas/FspId'
+        extensionList:
+          $ref: '#/components/schemas/extensionListEmptiable'
+    AmountType:
+      title: AmountType
+      type: string
+      enum:
+        - SEND
+        - RECEIVE
+      description: >-
+        Below are the allowed values for the enumeration AmountType.
+
+        - SEND - Amount the Payer would like to send, that is, the amount that
+        should be withdrawn from the Payer account including any fees.
+
+        - RECEIVE - Amount the Payer would like the Payee to receive, that is,
+        the amount that should be sent to the receiver exclusive of any fees.
+      example: RECEIVE
+    Amount:
+      title: Amount
+      type: string
+      pattern: ^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$
+      description: >-
+        The API data type Amount is a JSON String in a canonical format that is
+        restricted by a regular expression for interoperability reasons. This
+        pattern does not allow any trailing zeroes at all, but allows an amount
+        without a minor currency unit. It also only allows four digits in the
+        minor currency unit; a negative value is not allowed. Using more than 18
+        digits in the major currency unit is not allowed.
+      example: '123.45'
+    transferTransactionType:
+      title: transferTransactionType
+      type: string
+      enum:
+        - TRANSFER
+      description: Type of transaction.
+    TransactionSubScenario:
+      title: TransactionSubScenario
+      type: string
+      pattern: ^[A-Z_]{1,32}$
+      description: >-
+        Possible sub-scenario, defined locally within the scheme (UndefinedEnum
+        Type).
+      example: LOCALLY_DEFINED_SUBSCENARIO
+    Note:
+      title: Note
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Memo assigned to transaction.
+      example: Note sent to Payee.
+    individualQuote:
+      title: IndividualQuote
+      type: object
+      description: Data model for the complex type 'individualQuote'.
+      properties:
+        quoteId:
+          $ref: '#/components/schemas/CorrelationId'
         to:
           $ref: '#/components/schemas/transferParty'
         amountType:
@@ -1246,57 +1173,506 @@ components:
         amount:
           $ref: '#/components/schemas/Amount'
         transactionType:
-          $ref: '#/components/schemas/transactionType'
+          $ref: '#/components/schemas/transferTransactionType'
+        subScenario:
+          $ref: '#/components/schemas/TransactionSubScenario'
         note:
           $ref: '#/components/schemas/Note'
-        currentState:
-          $ref: '#/components/schemas/transferStatus'
-        quoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        quoteResponse:
-          $ref: '#/components/schemas/QuotesIDPutResponse'
-        quoteResponseSource:
+        extensions:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - quoteId
+        - to
+        - amountType
+        - currency
+        - transactionType
+        - amount
+    bulkQuoteRequest:
+      type: object
+      required:
+        - homeTransactionId
+        - from
+        - individualQuotes
+      properties:
+        homeTransactionId:
           type: string
-          description: >
-            FSPID of the entity that supplied the quote response. This may not
-            be the same as the FSPID of the entity which owns the end user
-            account in the case of a FOREX transfer. i.e. it may be a FOREX
-            gateway.
-        fulfil:
-          $ref: '#/components/schemas/TransfersIDPutResponse'
-        lastError:
-          $ref: '#/components/schemas/transferError'
-    errorResponse:
+          description: >-
+            Transaction ID from the DFSP backend, used to reconcile transactions
+            between the Switch and DFSP backend systems.
+        bulkQuoteId:
+          $ref: '#/components/schemas/CorrelationId'
+        from:
+          $ref: '#/components/schemas/transferParty'
+        individualQuotes:
+          description: List of individual quotes in a bulk quote.
+          type: array
+          minItems: 1
+          maxItems: 1000
+          items:
+            $ref: '#/components/schemas/individualQuote'
+        extensions:
+          $ref: '#/components/schemas/ExtensionList'
+    DateTime:
+      title: DateTime
+      type: string
+      pattern: >-
+        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
+      description: >-
+        The API data type DateTime is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons. The
+        format is according to [ISO
+        8601](https://www.iso.org/iso-8601-date-and-time-format.html), expressed
+        in a combined date, time and time zone format. A more readable version
+        of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples are
+        "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z
+        indicates Zulu time zone, same as UTC).
+      example: '2016-05-24T08:38:08.699-04:00'
+    bulkTransferStatus:
+      type: string
+      enum:
+        - ERROR_OCCURRED
+        - COMPLETED
+    Money:
+      title: Money
+      type: object
+      description: Data model for the complex type Money.
+      properties:
+        currency:
+          $ref: '#/components/schemas/Currency'
+        amount:
+          $ref: '#/components/schemas/Amount'
+      required:
+        - currency
+        - amount
+    Latitude:
+      title: Latitude
+      type: string
+      pattern: >-
+        ^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$
+      description: >-
+        The API data type Latitude is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons.
+      example: '+45.4215'
+    Longitude:
+      title: Longitude
+      type: string
+      pattern: >-
+        ^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$
+      description: >-
+        The API data type Longitude is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons.
+      example: '+75.6972'
+    GeoCode:
+      title: GeoCode
+      type: object
+      description: >-
+        Data model for the complex type GeoCode. Indicates the geographic
+        location from where the transaction was initiated.
+      properties:
+        latitude:
+          $ref: '#/components/schemas/Latitude'
+        longitude:
+          $ref: '#/components/schemas/Longitude'
+      required:
+        - latitude
+        - longitude
+    IlpPacket:
+      title: IlpPacket
+      type: string
+      pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
+      minLength: 1
+      maxLength: 32768
+      description: Information for recipient (transport layer information).
+      example: >-
+        AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
+    IlpCondition:
+      title: IlpCondition
+      type: string
+      pattern: ^[A-Za-z0-9-_]{43}$
+      maxLength: 48
+      description: Condition that must be attached to the transfer by the Payer.
+    quoteError:
+      type: object
+      description: >-
+        This object represents a Mojaloop API error received at any time during
+        the quote process
+      properties:
+        httpStatusCode:
+          type: integer
+          description: >-
+            The HTTP status code returned to the caller. This is the same as the
+            actual HTTP status code returned with the response.
+        mojaloopError:
+          $ref: '#/components/schemas/mojaloopError'
+    individualQuoteResult:
       type: object
       properties:
-        statusCode:
+        quoteId:
+          $ref: '#/components/schemas/CorrelationId'
+        transferAmount:
+          $ref: '#/components/schemas/Money'
+        payeeReceiveAmount:
+          $ref: '#/components/schemas/Money'
+        payeeFspFee:
+          $ref: '#/components/schemas/Money'
+        payeeFspCommission:
+          $ref: '#/components/schemas/Money'
+        geoCode:
+          $ref: '#/components/schemas/GeoCode'
+        ilpPacket:
+          $ref: '#/components/schemas/IlpPacket'
+        condition:
+          $ref: '#/components/schemas/IlpCondition'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+        lastError:
+          $ref: '#/components/schemas/quoteError'
+      required:
+        - quoteId
+    bulkQuoteResponse:
+      type: object
+      required:
+        - bulkQuoteId
+        - individualQuoteResults
+        - currentState
+        - expiration
+      properties:
+        bulkQuoteId:
+          $ref: '#/components/schemas/CorrelationId'
+        homeTransactionId:
           type: string
-          description: Error code as string.
-        message:
-          type: string
-          description: Error message text.
-    errorTransferResponse:
+          description: >-
+            Transaction ID from the DFSP backend, used to reconcile transactions
+            between the Switch and DFSP backend systems.
+        expiration:
+          $ref: '#/components/schemas/DateTime'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+        currentState:
+          $ref: '#/components/schemas/bulkTransferStatus'
+        individualQuoteResults:
+          type: array
+          maxItems: 1000
+          items:
+            $ref: '#/components/schemas/individualQuoteResult'
+          description: List of individualQuoteResults in a bulk transfer response.
+    bulkQuoteErrorResponse:
       allOf:
         - $ref: '#/components/schemas/errorResponse'
         - type: object
           required:
-            - transferState
+            - bulkQuoteState
           properties:
-            transferState:
-              $ref: '#/components/schemas/transferResponse'
-    transferStatusResponse:
+            bulkQuoteState:
+              $ref: '#/components/schemas/bulkQuoteResponse'
+    bulkQuoteStatus:
+      type: string
+      enum:
+        - ERROR_OCCURRED
+        - COMPLETED
+    bulkQuoteStatusResponse:
+      type: object
+      required:
+        - bulkQuoteId
+        - currentState
+        - individualQuotes
+      properties:
+        bulkQuoteId:
+          $ref: '#/components/schemas/CorrelationId'
+        currentState:
+          $ref: '#/components/schemas/bulkQuoteStatus'
+        individualQuotes:
+          type: array
+          minItems: 1
+          maxItems: 1000
+          items:
+            $ref: '#/components/schemas/individualQuote'
+    autoAcceptPartyOption:
+      type: object
+      required:
+        - enabled
+      properties:
+        enabled:
+          type: boolean
+          enum:
+            - false
+            - true
+    bulkPerTransferFeeLimit:
+      type: object
+      required:
+        - currency
+        - amount
+      properties:
+        currency:
+          $ref: '#/components/schemas/Currency'
+        amount:
+          $ref: '#/components/schemas/Amount'
+    autoAcceptQuote:
+      type: object
+      required:
+        - enabled
+      properties:
+        enabled:
+          type: boolean
+          enum:
+            - true
+            - false
+        perTransferFeeLimits:
+          type: array
+          minItems: 0
+          items:
+            $ref: '#/components/schemas/bulkPerTransferFeeLimit'
+    bulkTransactionOptions:
+      type: object
+      required:
+        - autoAcceptParty
+        - autoAcceptQuote
+        - bulkExpiration
+      properties:
+        onlyValidateParty:
+          description: >-
+            Set to true if only party validation is required.  This means the
+            quotes and transfers will not run. This is useful for only party
+            resolution.
+          type: boolean
+        autoAcceptParty:
+          $ref: '#/components/schemas/autoAcceptPartyOption'
+        autoAcceptQuote:
+          description: >-
+            Set to true if the quote response is accepted without confirmation
+            from the payer. The fees applied by the payee will be acceptable to
+            the payer abiding by the limits set by optional
+            'perTransferFeeLimits' array.
+          type: object
+          oneOf:
+            - $ref: '#/components/schemas/autoAcceptQuote'
+        skipPartyLookup:
+          description: >-
+            Set to true if supplying an FSPID for the payee party and no party
+            resolution is needed. This may be useful if a previous party
+            resolution has been performed.
+          type: boolean
+        synchronous:
+          description: >-
+            Set to true if the bulkTransfer requests need be handled
+            synchronous. Otherwise the requests will be handled asynchronously,
+            meaning there will  be callbacks whenever the processing is done
+          type: boolean
+        bulkExpiration:
+          $ref: '#/components/schemas/DateTime'
+    PartyIdInfo:
+      title: PartyIdInfo
+      type: object
+      description: >-
+        Data model for the complex type PartyIdInfo. An ExtensionList element
+        has been added to this reqeust in version v1.1
+      properties:
+        partyIdType:
+          $ref: '#/components/schemas/PartyIdType'
+        partyIdentifier:
+          $ref: '#/components/schemas/PartyIdentifier'
+        partySubIdOrType:
+          $ref: '#/components/schemas/PartySubIdOrType'
+        fspId:
+          $ref: '#/components/schemas/FspId'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - partyIdType
+        - partyIdentifier
+    PartyName:
+      title: PartyName
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Name of the Party. Could be a real name or a nickname.
+    PartyComplexName:
+      title: PartyComplexName
+      type: object
+      description: Data model for the complex type PartyComplexName.
+      properties:
+        firstName:
+          $ref: '#/components/schemas/FirstName'
+        middleName:
+          $ref: '#/components/schemas/MiddleName'
+        lastName:
+          $ref: '#/components/schemas/LastName'
+    PartyPersonalInfo:
+      title: PartyPersonalInfo
+      type: object
+      description: Data model for the complex type PartyPersonalInfo.
+      properties:
+        complexName:
+          $ref: '#/components/schemas/PartyComplexName'
+        dateOfBirth:
+          $ref: '#/components/schemas/DateOfBirth'
+    Party:
+      title: Party
+      type: object
+      description: Data model for the complex type Party.
+      properties:
+        partyIdInfo:
+          $ref: '#/components/schemas/PartyIdInfo'
+        merchantClassificationCode:
+          $ref: '#/components/schemas/MerchantClassificationCode'
+        name:
+          $ref: '#/components/schemas/PartyName'
+        personalInfo:
+          $ref: '#/components/schemas/PartyPersonalInfo'
+      required:
+        - partyIdInfo
+    bulkTransactionIndividualTransfer:
+      title: BulkTransactionIndividualTransfer
+      type: object
+      description: Data model for the complex type 'bulkTransactionIndividualTransfer'.
+      properties:
+        homeTransactionId:
+          type: string
+          description: >-
+            Transaction ID from the DFSP backend, used to reconcile transactions
+            between the Switch and DFSP backend systems.
+        to:
+          $ref: '#/components/schemas/Party'
+        reference:
+          description: Payer Loan reference
+          type: string
+        amountType:
+          $ref: '#/components/schemas/AmountType'
+        currency:
+          $ref: '#/components/schemas/Currency'
+        amount:
+          $ref: '#/components/schemas/Amount'
+        note:
+          $ref: '#/components/schemas/Note'
+        quoteExtensions:
+          $ref: '#/components/schemas/ExtensionList'
+        transferExtensions:
+          $ref: '#/components/schemas/ExtensionList'
+        lastError:
+          $ref: '#/components/schemas/transferError'
+      required:
+        - homeTransactionId
+        - to
+        - amountType
+        - currency
+        - amount
+    bulkTransactionRequest:
+      type: object
+      required:
+        - bulkTransactionId
+        - bulkHomeTransactionID
+        - options
+        - from
+        - individualTransfers
+      properties:
+        bulkHomeTransactionID:
+          type: string
+          description: >-
+            Transaction ID from the DFSP backend, used to reconcile transactions
+            between the Switch and DFSP backend systems.
+        bulkTransactionId:
+          $ref: '#/components/schemas/CorrelationId'
+        options:
+          $ref: '#/components/schemas/bulkTransactionOptions'
+        from:
+          $ref: '#/components/schemas/Party'
+        individualTransfers:
+          description: List of individual transfers in a bulk transfer.
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/bulkTransactionIndividualTransfer'
+        extensions:
+          $ref: '#/components/schemas/ExtensionList'
+    TransferState:
+      title: TransferState
+      type: string
+      enum:
+        - RECEIVED
+        - RESERVED
+        - COMMITTED
+        - ABORTED
+      description: >-
+        Below are the allowed values for the enumeration.
+
+        - RECEIVED - Next ledger has received the transfer.
+
+        - RESERVED - Next ledger has reserved the transfer.
+
+        - COMMITTED - Next ledger has successfully performed the transfer.
+
+        - ABORTED - Next ledger has aborted the transfer due to a rejection or
+        failure to perform the transfer.
+      example: RESERVED
+    IlpFulfilment:
+      title: IlpFulfilment
+      type: string
+      pattern: ^[A-Za-z0-9-_]{43}$
+      maxLength: 48
+      description: Fulfilment that must be attached to the transfer by the Payee.
+      example: WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8
+    individualTransferResult:
       type: object
       required:
         - transferId
-        - currentState
-        - fulfil
       properties:
         transferId:
           $ref: '#/components/schemas/CorrelationId'
+        fulfilment:
+          $ref: '#/components/schemas/IlpFulfilment'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+        transferState:
+          $ref: '#/components/schemas/TransferState'
+        lastError:
+          $ref: '#/components/schemas/transferError'
+    bulkTransferResponse:
+      type: object
+      required:
+        - bulkTransferId
+        - individualTransferResults
+        - currentState
+      properties:
+        bulkTransferId:
+          $ref: '#/components/schemas/CorrelationId'
+        bulkQuoteId:
+          $ref: '#/components/schemas/CorrelationId'
+        homeTransactionId:
+          type: string
+          description: >-
+            Transaction ID from the DFSP backend, used to reconcile transactions
+            between the Switch and DFSP backend systems.
+        bulkTransferState:
+          $ref: '#/components/schemas/TransferState'
+        completedTimestamp:
+          $ref: '#/components/schemas/DateTime'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
         currentState:
-          $ref: '#/components/schemas/transferStatus'
-        fulfil:
-          $ref: '#/components/schemas/TransfersIDPutResponse'
+          $ref: '#/components/schemas/bulkTransferStatus'
+        individualTransferResults:
+          type: array
+          maxItems: 1000
+          items:
+            $ref: '#/components/schemas/individualTransferResult'
+          description: List of individual transfer result in a bulk transfer response.
+    bulkTransferErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/errorResponse'
+        - type: object
+          required:
+            - bulkTransferState
+          properties:
+            bulkTransferState:
+              $ref: '#/components/schemas/bulkTransferResponse'
+    bulkTransactionIndividualTransferAccept:
+      type: object
+      description: Data model for the 'individualTransfer' while accepting party or quote.
+      properties:
+        transferId:
+          $ref: '#/components/schemas/CorrelationId'
+      required:
+        - transferId
     transferContinuationAcceptParty:
       type: object
       required:
@@ -1306,6 +1682,25 @@ components:
           type: boolean
           enum:
             - true
+            - false
+    bulkTransactionContinuationAcceptParty:
+      description: >-
+        The object sent back as confirmation of payee parties when
+        autoAcceptParty is false.
+      type: object
+      required:
+        - individualTransfers
+      properties:
+        individualTransfers:
+          description: >-
+            List of individual transfers in a bulk transfer with accept party
+            information.
+          type: array
+          minItems: 1
+          items:
+            allOf:
+              - $ref: '#/components/schemas/bulkTransactionIndividualTransferAccept'
+              - $ref: '#/components/schemas/transferContinuationAcceptParty'
     transferContinuationAcceptQuote:
       type: object
       required:
@@ -1316,6 +1711,57 @@ components:
           enum:
             - true
             - false
+    bulkTransactionContinuationAcceptQuote:
+      description: >-
+        The object sent back as confirmation of quotes when autoAcceptQuotes is
+        false.
+      type: object
+      required:
+        - individualTransfers
+      properties:
+        individualTransfers:
+          description: List of individual transfers in a bulk transfer.
+          type: array
+          minItems: 1
+          items:
+            allOf:
+              - $ref: '#/components/schemas/bulkTransactionIndividualTransferAccept'
+              - $ref: '#/components/schemas/transferContinuationAcceptQuote'
+    partyError:
+      type: object
+      description: >-
+        This object represents a Mojaloop API error received at any time during
+        the party discovery process
+      properties:
+        httpStatusCode:
+          type: integer
+          description: >-
+            The HTTP status code returned to the caller. This is the same as the
+            actual HTTP status code returned with the response.
+        mojaloopError:
+          $ref: '#/components/schemas/mojaloopError'
+    bulkTransactionAcceptPartyErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/errorResponse'
+        - type: object
+          required:
+            - bulkTransferState
+          properties:
+            bulkTransferState:
+              allOf:
+                - $ref: '#/components/schemas/bulkTransactionContinuationAcceptParty'
+                - $ref: '#/components/schemas/partyError'
+    bulkTransactionAcceptQuoteErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/errorResponse'
+        - type: object
+          required:
+            - bulkTansferState
+          properties:
+            bulkTransferState:
+              allOf:
+                - $ref: '#/components/schemas/bulkTransactionContinuationAcceptQuote'
+                - $ref: '#/components/schemas/quoteError'
     individualTransfer:
       title: IndividualTransfer
       type: object
@@ -1332,7 +1778,13 @@ components:
         amount:
           $ref: '#/components/schemas/Amount'
         transactionType:
-          $ref: '#/components/schemas/transactionType'
+          $ref: '#/components/schemas/transferTransactionType'
+        subScenario:
+          $ref: '#/components/schemas/TransactionSubScenario'
+        ilpPacket:
+          $ref: '#/components/schemas/IlpPacket'
+        condition:
+          $ref: '#/components/schemas/IlpCondition'
         note:
           $ref: '#/components/schemas/Note'
         extensions:
@@ -1342,11 +1794,15 @@ components:
         - to
         - amountType
         - currency
-        - transactionType
+        - amount
+        - ilpPacket
+        - condition
     bulkTransferRequest:
       type: object
       required:
+        - bulkTransferId
         - homeTransactionId
+        - bulkQuoteId
         - from
         - individualTransfers
       properties:
@@ -1356,6 +1812,8 @@ components:
             Transaction ID from the DFSP backend, used to reconcile transactions
             between the Switch and DFSP backend systems.
         bulkTransferId:
+          $ref: '#/components/schemas/CorrelationId'
+        bulkQuoteId:
           $ref: '#/components/schemas/CorrelationId'
         from:
           $ref: '#/components/schemas/transferParty'
@@ -1368,68 +1826,6 @@ components:
             $ref: '#/components/schemas/individualTransfer'
         extensions:
           $ref: '#/components/schemas/ExtensionList'
-    individualTransferResult:
-      type: object
-      properties:
-        transferId:
-          $ref: '#/components/schemas/CorrelationId'
-        to:
-          $ref: '#/components/schemas/transferParty'
-        amountType:
-          $ref: '#/components/schemas/AmountType'
-        currency:
-          $ref: '#/components/schemas/Currency'
-        amount:
-          $ref: '#/components/schemas/Amount'
-        transactionType:
-          $ref: '#/components/schemas/transactionType'
-        note:
-          $ref: '#/components/schemas/Note'
-        quoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        quoteResponse:
-          $ref: '#/components/schemas/QuotesIDPutResponse'
-        quoteResponseSource:
-          type: string
-          description: >
-            FSPID of the entity that supplied the quote response. This may not
-            be the same as the FSPID of the entity which owns the end user
-            account in the case of a FOREX transfer. i.e. it may be a FOREX
-            gateway.
-        fulfil:
-          $ref: '#/components/schemas/TransfersIDPutResponse'
-        lastError:
-          $ref: '#/components/schemas/transferError'
-    bulkTransferResponse:
-      type: object
-      required:
-        - from
-        - individualTransferResults
-      properties:
-        transferId:
-          $ref: '#/components/schemas/CorrelationId'
-        from:
-          $ref: '#/components/schemas/transferParty'
-        individualTransferResults:
-          type: array
-          maxItems: 1000
-          items:
-            $ref: '#/components/schemas/individualTransferResult'
-          description: List of individual transfer result in a bulk transfer response.
-    bulkTransferErrorResponse:
-      allOf:
-        - $ref: '#/components/schemas/errorResponse'
-        - type: object
-          required:
-            - bulkTansferState
-          properties:
-            bulkTransferState:
-              $ref: '#/components/schemas/bulkTransferResponse'
-    bulkTransferStatus:
-      type: string
-      enum:
-        - ERROR_OCCURRED
-        - COMPLETED
     individualTransferFulfilment:
       type: object
       description: >-
@@ -1457,142 +1853,32 @@ components:
           maxItems: 1000
           items:
             $ref: '#/components/schemas/individualTransferFulfilment'
-    individualQuote:
-      title: IndividualQuote
-      type: object
-      description: Data model for the complex type 'individualQuote'.
-      properties:
-        quoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        to:
-          $ref: '#/components/schemas/transferParty'
-        amountType:
-          $ref: '#/components/schemas/AmountType'
-        currency:
-          $ref: '#/components/schemas/Currency'
-        amount:
-          $ref: '#/components/schemas/Amount'
-        transactionType:
-          $ref: '#/components/schemas/transactionType'
-        note:
-          $ref: '#/components/schemas/Note'
-        extensions:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - quoteId
-        - to
-        - amountType
-        - currency
-        - transactionType
-    bulkQuoteRequest:
-      type: object
-      required:
-        - homeTransactionId
-        - from
-        - individualQuotes
-      properties:
-        homeTransactionId:
-          type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
-        bulkQuoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        from:
-          $ref: '#/components/schemas/transferParty'
-        individualQuotes:
-          description: List of individual quotes in a bulk quote.
-          type: array
-          minItems: 1
-          maxItems: 1000
-          items:
-            $ref: '#/components/schemas/individualQuote'
-        extensions:
-          $ref: '#/components/schemas/ExtensionList'
-    quoteError:
-      type: object
-      description: >-
-        This object represents a Mojaloop API error received at any time during
-        the quote process
-      properties:
-        httpStatusCode:
-          type: integer
-          description: >-
-            The HTTP status code returned to the caller. This is the same as the
-            actual HTTP status code returned with the response.
-        mojaloopError:
-          $ref: '#/components/schemas/mojaloopError'
-    individualQuoteResult:
-      type: object
-      properties:
-        quoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        to:
-          $ref: '#/components/schemas/transferParty'
-        amountType:
-          $ref: '#/components/schemas/AmountType'
-        currency:
-          $ref: '#/components/schemas/Currency'
-        amount:
-          $ref: '#/components/schemas/Amount'
-        transactionType:
-          $ref: '#/components/schemas/transactionType'
-        note:
-          $ref: '#/components/schemas/Note'
-        lastError:
-          $ref: '#/components/schemas/quoteError'
-    bulkQuoteResponse:
-      type: object
-      required:
-        - from
-        - individualQuoteResults
-      properties:
-        quoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        homeTransactionId:
-          type: string
-          description: >-
-            Transaction ID from the DFSP backend, used to reconcile transactions
-            between the Switch and DFSP backend systems.
-        from:
-          $ref: '#/components/schemas/transferParty'
-        individualQuoteResults:
-          type: array
-          maxItems: 1000
-          items:
-            $ref: '#/components/schemas/individualQuoteResult'
-          description: List of individualQuoteResults in a bulk transfer response.
-    bulkQuoteErrorResponse:
-      allOf:
-        - $ref: '#/components/schemas/errorResponse'
-        - type: object
-          required:
-            - bulkTansferState
-          properties:
-            bulkQuoteState:
-              $ref: '#/components/schemas/bulkQuoteResponse'
-    bulkQuoteStatus:
+    async2SyncCurrentState:
       type: string
       enum:
-        - ERROR_OCCURRED
+        - WAITING_FOR_ACTION
         - COMPLETED
-    bulkQuoteStatusResponse:
+        - ERROR_OCCURRED
+    partiesByIdResponse:
+      title: partiesByIdResponse
       type: object
-      required:
-        - bulkQuoteId
-        - currentState
-        - individualQuotes
+      description: GET /parties/{Type}/{ID} response object
       properties:
-        bulkQuoteId:
-          $ref: '#/components/schemas/CorrelationId'
+        party:
+          properties:
+            body:
+              $ref: '#/components/schemas/Party'
+              description: Information regarding the requested Party.
+            headers:
+              type: object
+          required:
+            - body
+            - headers
         currentState:
-          $ref: '#/components/schemas/bulkQuoteStatus'
-        individualQuotes:
-          type: array
-          minItems: 1
-          maxItems: 1000
-          items:
-            $ref: '#/components/schemas/individualQuote'
+          $ref: '#/components/schemas/async2SyncCurrentState'
+      required:
+        - party
+        - currentState
     TransactionScenario:
       title: TransactionScenario
       type: string
@@ -1625,13 +1911,7 @@ components:
         User are present, a bill payment, a donation, and so on.
 
         - REFUND - Used for performing a refund of transaction.
-    TransactionSubScenario:
-      title: TransactionSubScenario
-      type: string
-      pattern: '^[A-Z_]{1,32}$'
-      description: >-
-        Possible sub-scenario, defined locally within the scheme (UndefinedEnum
-        Type).
+      example: DEPOSIT
     TransactionInitiator:
       title: TransactionInitiator
       type: string
@@ -1649,12 +1929,14 @@ components:
         sending a transaction request. The Payer must approve the transaction,
         either automatically by a pre-generated OTP or by pre-approval of the
         Payee, or by manually approving in his or her own Device.
+      example: PAYEE
     RefundReason:
       title: RefundReason
       type: string
       minLength: 1
       maxLength: 128
       description: Reason for the refund.
+      example: Free text indicating reason for the refund.
     Refund:
       title: Refund
       type: object
@@ -1669,12 +1951,13 @@ components:
     BalanceOfPayments:
       title: BalanceOfPayments
       type: string
-      pattern: '^[1-9]\d{2}$'
+      pattern: ^[1-9]\d{2}$
       description: >-
         (BopCode) The API data type
         [BopCode](https://www.imf.org/external/np/sta/bopcode/) is a JSON String
         of 3 characters, consisting of digits only. Negative numbers are not
         allowed. A leading zero is not allowed.
+      example: '123'
     TransactionType:
       title: TransactionType
       type: object
@@ -1696,6 +1979,110 @@ components:
         - scenario
         - initiator
         - initiatorType
+    QuotesPostRequest:
+      title: QuotesPostRequest
+      type: object
+      description: The object sent in the POST /quotes request.
+      properties:
+        quoteId:
+          $ref: '#/components/schemas/CorrelationId'
+        transactionId:
+          $ref: '#/components/schemas/CorrelationId'
+        transactionRequestId:
+          $ref: '#/components/schemas/CorrelationId'
+        payee:
+          $ref: '#/components/schemas/Party'
+        payer:
+          $ref: '#/components/schemas/Party'
+        amountType:
+          $ref: '#/components/schemas/AmountType'
+        amount:
+          $ref: '#/components/schemas/Money'
+        fees:
+          $ref: '#/components/schemas/Money'
+        transactionType:
+          $ref: '#/components/schemas/TransactionType'
+        geoCode:
+          $ref: '#/components/schemas/GeoCode'
+        note:
+          $ref: '#/components/schemas/Note'
+        expiration:
+          $ref: '#/components/schemas/DateTime'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - quoteId
+        - transactionId
+        - payee
+        - payer
+        - amountType
+        - amount
+        - transactionType
+    simpleQuotesPostRequest:
+      title: simpleQuotesPostRequest
+      type: object
+      properties:
+        fspId:
+          title: destination DFSP requested to calculate the quote
+          $ref: '#/components/schemas/FspId'
+        quotesPostRequest:
+          $ref: '#/components/schemas/QuotesPostRequest'
+      required:
+        - fspId
+        - quotesPostRequest
+    quotesPostResponse:
+      title: QuotesPostResponse
+      type: object
+      properties:
+        quotes:
+          title: QuotesIDPutResponse
+          type: object
+          description: The object sent in the PUT /quotes/{ID} callback.
+          properties:
+            body:
+              type: object
+              properties:
+                transferAmount:
+                  $ref: '#/components/schemas/Money'
+                payeeReceiveAmount:
+                  $ref: '#/components/schemas/Money'
+                payeeFspFee:
+                  $ref: '#/components/schemas/Money'
+                payeeFspCommission:
+                  $ref: '#/components/schemas/Money'
+                expiration:
+                  type: string
+                  description: >-
+                    Date and time until when the quotation is valid and can be
+                    honored when used in the subsequent transaction.
+                  example: '2016-05-24T08:38:08.699-04:00'
+                geoCode:
+                  $ref: '#/components/schemas/GeoCode'
+                ilpPacket:
+                  $ref: '#/components/schemas/IlpPacket'
+                condition:
+                  $ref: '#/components/schemas/IlpCondition'
+                extensionList:
+                  $ref: '#/components/schemas/ExtensionList'
+              required:
+                - transferAmount
+                - expiration
+                - ilpPacket
+                - condition
+            headers:
+              type: object
+          required:
+            - body
+            - headers
+        currentState:
+          $ref: '#/components/schemas/async2SyncCurrentState'
+      required:
+        - quotes
+        - currentState
+    errorQuotesResponse:
+      allOf:
+        - $ref: '#/components/schemas/errorResponse'
+        - type: object
     requestToPayRequest:
       type: object
       required:
@@ -1705,9 +2092,7 @@ components:
         - amountType
         - currency
         - amount
-        - scenario
-        - initiator
-        - initiatorType
+        - transactionType
       properties:
         homeTransactionId:
           type: string
@@ -1724,52 +2109,38 @@ components:
           $ref: '#/components/schemas/Currency'
         amount:
           $ref: '#/components/schemas/Amount'
-        scenario:
-          $ref: '#/components/schemas/TransactionType'
-        initiator:
-          $ref: '#/components/schemas/TransactionInitiator'
-        initiatorType:
-          $ref: '#/components/schemas/TransactionInitiatorType'
-    AuthenticationType:
-      title: AuthenticationType
+        transactionType:
+          $ref: '#/components/schemas/TransactionScenario'
+        subScenario:
+          $ref: '#/components/schemas/TransactionSubScenario'
+    transferStatus:
       type: string
       enum:
-        - OTP
-        - QRCODE
-        - U2F
-      description: |-
-        Below are the allowed values for the enumeration AuthenticationType.
-        - OTP - One-time password generated by the Payer FSP.
-        - QRCODE - QR code used as One Time Password.
-        - U2F - U2F is a new addition isolated to Thirdparty stream.
-    TransactionRequestState:
-      title: TransactionRequestState
-      type: string
-      enum:
-        - RECEIVED
-        - PENDING
-        - ACCEPTED
-        - REJECTED
-      description: |-
-        Below are the allowed values for the enumeration.
-        - RECEIVED - Payer FSP has received the transaction from the Payee FSP.
-        - PENDING - Payer FSP has sent the transaction request to the Payer.
-        - ACCEPTED - Payer has approved the transaction.
-        - REJECTED - Payer has rejected the transaction.
+        - ERROR_OCCURRED
+        - WAITING_FOR_PARTY_ACCEPTANCE
+        - WAITING_FOR_QUOTE_ACCEPTANCE
+        - COMPLETED
     requestToPayResponse:
       type: object
       required:
-        - transactionRequestId
+        - requestToPayId
         - from
         - to
         - amountType
         - currency
         - amount
         - transactionType
-        - requestToPayState
+        - currentState
       properties:
+        requestToPayId:
+          $ref: '#/components/schemas/CorrelationId'
         transactionRequestId:
           $ref: '#/components/schemas/CorrelationId'
+        homeTransactionId:
+          type: string
+          description: >-
+            Transaction ID from the DFSP backend, used to reconcile transactions
+            between the Switch and DFSP backend systems.
         from:
           $ref: '#/components/schemas/transferParty'
         to:
@@ -1780,16 +2151,165 @@ components:
           $ref: '#/components/schemas/Currency'
         amount:
           $ref: '#/components/schemas/Amount'
-        scenario:
-          $ref: '#/components/schemas/TransactionType'
-        initiator:
-          $ref: '#/components/schemas/TransactionInitiator'
-        initiatorType:
-          $ref: '#/components/schemas/TransactionInitiatorType'
-        authenticationType:
-          $ref: '#/components/schemas/AuthenticationType'
-        requestToPayState:
-          $ref: '#/components/schemas/TransactionRequestState'
+        transactionType:
+          $ref: '#/components/schemas/TransactionScenario'
+        subScenario:
+          $ref: '#/components/schemas/TransactionSubScenario'
+        currentState:
+          $ref: '#/components/schemas/transferStatus'
+        getPartiesResponse:
+          type: object
+          required:
+            - body
+          properties:
+            body:
+              type: object
+            headers:
+              type: object
+        lastError:
+          description: >
+            Object representing the last error to occur during a transfer
+            process. This may be a Mojaloop API error returned from another
+            entity in the scheme or an object representing other types of error
+            e.g. exceptions that may occur inside the scheme adapter.
+          $ref: '#/components/schemas/transferError'
+    QuotesIDPutResponse:
+      title: QuotesIDPutResponse
+      type: object
+      description: The object sent in the PUT /quotes/{ID} callback.
+      properties:
+        transferAmount:
+          $ref: '#/components/schemas/Money'
+        payeeReceiveAmount:
+          $ref: '#/components/schemas/Money'
+        payeeFspFee:
+          $ref: '#/components/schemas/Money'
+        payeeFspCommission:
+          $ref: '#/components/schemas/Money'
+        expiration:
+          $ref: '#/components/schemas/DateTime'
+        geoCode:
+          $ref: '#/components/schemas/GeoCode'
+        ilpPacket:
+          $ref: '#/components/schemas/IlpPacket'
+        condition:
+          $ref: '#/components/schemas/IlpCondition'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - transferAmount
+        - expiration
+        - ilpPacket
+        - condition
+    TransfersIDPutResponse:
+      title: TransfersIDPutResponse
+      type: object
+      description: The object sent in the PUT /transfers/{ID} callback.
+      properties:
+        fulfilment:
+          $ref: '#/components/schemas/IlpFulfilment'
+        completedTimestamp:
+          $ref: '#/components/schemas/DateTime'
+        transferState:
+          $ref: '#/components/schemas/TransferState'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - transferState
+    transferResponse:
+      type: object
+      required:
+        - homeTransactionId
+        - from
+        - to
+        - amountType
+        - currency
+        - amount
+        - transactionType
+      properties:
+        transferId:
+          $ref: '#/components/schemas/CorrelationId'
+        homeTransactionId:
+          type: string
+          description: >-
+            Transaction ID from the DFSP backend, used to reconcile transactions
+            between the Switch and DFSP backend systems.
+        from:
+          $ref: '#/components/schemas/transferParty'
+        to:
+          $ref: '#/components/schemas/transferParty'
+        amountType:
+          $ref: '#/components/schemas/AmountType'
+        currency:
+          $ref: '#/components/schemas/Currency'
+        amount:
+          $ref: '#/components/schemas/Amount'
+        transactionType:
+          $ref: '#/components/schemas/transferTransactionType'
+        subScenario:
+          $ref: '#/components/schemas/TransactionSubScenario'
+        note:
+          $ref: '#/components/schemas/Note'
+        currentState:
+          $ref: '#/components/schemas/transferStatus'
+        quoteId:
+          $ref: '#/components/schemas/CorrelationId'
+        getPartiesResponse:
+          type: object
+          required:
+            - body
+          properties:
+            body:
+              type: object
+            headers:
+              type: object
+        quoteResponse:
+          type: object
+          required:
+            - body
+          properties:
+            body:
+              $ref: '#/components/schemas/QuotesIDPutResponse'
+            headers:
+              type: object
+        quoteResponseSource:
+          type: string
+          description: >
+            FSPID of the entity that supplied the quote response. This may not
+            be the same as the FSPID of the entity which owns the end user
+            account in the case of a FOREX transfer. i.e. it may be a FOREX
+            gateway.
+        fulfil:
+          type: object
+          required:
+            - body
+          properties:
+            body:
+              $ref: '#/components/schemas/TransfersIDPutResponse'
+            headers:
+              type: object
+        lastError:
+          description: >
+            Object representing the last error to occur during a transfer
+            process. This may be a Mojaloop API error returned from another
+            entity in the scheme or an object representing other types of error
+            e.g. exceptions that may occur inside the scheme adapter.
+          $ref: '#/components/schemas/transferError'
+        skipPartyLookup:
+          description: >-
+            Set to true if supplying an FSPID for the payee party and no party
+            resolution is needed. This may be useful is a previous party
+            resolution has been performed.
+          type: boolean
+    errorTransferResponse:
+      allOf:
+        - $ref: '#/components/schemas/errorResponse'
+        - type: object
+          required:
+            - transferState
+          properties:
+            transferState:
+              $ref: '#/components/schemas/transferResponse'
     requestToPayTransferRequest:
       type: object
       required:
@@ -1855,7 +2375,7 @@ components:
         amount:
           $ref: '#/components/schemas/Amount'
         transactionType:
-          $ref: '#/components/schemas/transactionType'
+          $ref: '#/components/schemas/transferTransactionType'
         note:
           $ref: '#/components/schemas/Note'
         currentState:
@@ -1874,6 +2394,11 @@ components:
         fulfil:
           $ref: '#/components/schemas/TransfersIDPutResponse'
         lastError:
+          description: >
+            Object representing the last error to occur during a transfer
+            process. This may be a Mojaloop API error returned from another
+            entity in the scheme or an object representing other types of error
+            e.g. exceptions that may occur inside the scheme adapter.
           $ref: '#/components/schemas/transferError'
     transferContinuationAcceptOTP:
       type: object
@@ -1885,282 +2410,6 @@ components:
           enum:
             - true
             - false
-    accountsRequest:
-      type: array
-      items:
-        type: object
-        required:
-          - idType
-          - idValue
-          - currency
-        properties:
-          idType:
-            $ref: '#/components/schemas/PartyIdType'
-          idValue:
-            $ref: '#/components/schemas/PartyIdentifier'
-          idSubValue:
-            $ref: '#/components/schemas/PartySubIdOrType'
-          currency:
-            $ref: '#/components/schemas/Currency'
-    accountCreationStatus:
-      type: array
-      items:
-        type: object
-        required:
-          - idType
-          - idValue
-        properties:
-          idType:
-            $ref: '#/components/schemas/PartyIdType'
-          idValue:
-            $ref: '#/components/schemas/PartyIdentifier'
-          idSubValue:
-            $ref: '#/components/schemas/PartySubIdOrType'
-          error:
-            $ref: '#/components/schemas/errorResponse'
-    accountsCreationState:
-      type: string
-      enum:
-        - ERROR_OCCURRED
-        - COMPLETED
-    accountsResponse:
-      type: object
-      required:
-        - accounts
-      properties:
-        modelId:
-          $ref: '#/components/schemas/CorrelationId'
-        accounts:
-          $ref: '#/components/schemas/accountsRequest'
-        response:
-          $ref: '#/components/schemas/accountCreationStatus'
-        currentState:
-          $ref: '#/components/schemas/accountsCreationState'
-        lastError:
-          $ref: '#/components/schemas/transferError'
-    errorAccountsResponse:
-      allOf:
-        - $ref: '#/components/schemas/errorResponse'
-        - type: object
-          required:
-            - executionState
-          properties:
-            executionState:
-              $ref: '#/components/schemas/accountsResponse'
-    AccountAddress:
-      title: AccountAddress
-      type: string
-      description: >
-        A long-lived unique account identifier provided by the DFSP. This MUST
-        NOT
-
-        be Bank Account Number or anything that may expose a User's private bank
-
-        account information.
-      pattern: '^([0-9A-Za-z_~\-\.]+[0-9A-Za-z_~\-])$'
-      minLength: 1
-      maxLength: 1023
-    Account:
-      title: Account
-      type: object
-      description: Data model for the complex type Account.
-      properties:
-        address:
-          $ref: '#/components/schemas/AccountAddress'
-        currency:
-          $ref: '#/components/schemas/Currency'
-        description:
-          $ref: '#/components/schemas/Name'
-      required:
-        - currency
-    AccountList:
-      title: AccountList
-      type: object
-      description: Data model for the complex type AccountList.
-      properties:
-        account:
-          type: array
-          items:
-            $ref: '#/components/schemas/Account'
-          minItems: 1
-          maxItems: 32
-          description: Accounts associated with the Party.
-      required:
-        - account
-    PartyIdInfo:
-      title: PartyIdInfo
-      type: object
-      description: Data model for the complex type PartyIdInfo.
-      properties:
-        partyIdType:
-          $ref: '#/components/schemas/PartyIdType'
-        partyIdentifier:
-          $ref: '#/components/schemas/PartyIdentifier'
-        partySubIdOrType:
-          $ref: '#/components/schemas/PartySubIdOrType'
-        fspId:
-          $ref: '#/components/schemas/FspId'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - partyIdType
-        - partyIdentifier
-    PartyName:
-      title: PartyName
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Name of the Party. Could be a real name or a nickname.
-    PartyComplexName:
-      title: PartyComplexName
-      type: object
-      description: Data model for the complex type PartyComplexName.
-      properties:
-        firstName:
-          $ref: '#/components/schemas/FirstName'
-        middleName:
-          $ref: '#/components/schemas/MiddleName'
-        lastName:
-          $ref: '#/components/schemas/LastName'
-    PartyPersonalInfo:
-      title: PartyPersonalInfo
-      type: object
-      description: Data model for the complex type PartyPersonalInfo.
-      properties:
-        complexName:
-          $ref: '#/components/schemas/PartyComplexName'
-        dateOfBirth:
-          $ref: '#/components/schemas/DateOfBirth'
-    Party:
-      title: Party
-      type: object
-      description: Data model for the complex type Party.
-      properties:
-        accounts:
-          $ref: '#/components/schemas/AccountList'
-        partyIdInfo:
-          $ref: '#/components/schemas/PartyIdInfo'
-        merchantClassificationCode:
-          $ref: '#/components/schemas/MerchantClassificationCode'
-        name:
-          $ref: '#/components/schemas/PartyName'
-        personalInfo:
-          $ref: '#/components/schemas/PartyPersonalInfo'
-      required:
-        - partyIdInfo
-    async2SyncCurrentState:
-      type: string
-      enum:
-        - WAITING_FOR_ACTION
-        - COMPLETED
-        - ERROR_OCCURRED
-    partiesByIdResponse:
-      title: partiesByIdResponse
-      type: object
-      description: 'GET /parties/{Type}/{ID} response object'
-      properties:
-        party:
-          $ref: '#/components/schemas/Party'
-        currentState:
-          $ref: '#/components/schemas/async2SyncCurrentState'
-      required:
-        - party
-        - currentState
-    QuotesPostRequest:
-      title: QuotesPostRequest
-      type: object
-      description: The object sent in the POST /quotes request.
-      properties:
-        quoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        transactionId:
-          $ref: '#/components/schemas/CorrelationId'
-        transactionRequestId:
-          $ref: '#/components/schemas/CorrelationId'
-        payee:
-          $ref: '#/components/schemas/Party'
-        payer:
-          $ref: '#/components/schemas/Party'
-        amountType:
-          $ref: '#/components/schemas/AmountType'
-        amount:
-          $ref: '#/components/schemas/Money'
-        fees:
-          $ref: '#/components/schemas/Money'
-        transactionType:
-          $ref: '#/components/schemas/TransactionType'
-        geoCode:
-          $ref: '#/components/schemas/GeoCode'
-        note:
-          $ref: '#/components/schemas/Note'
-        expiration:
-          $ref: '#/components/schemas/DateTime'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - quoteId
-        - transactionId
-        - payee
-        - payer
-        - amountType
-        - amount
-        - transactionType
-    quotesPostRequest:
-      title: QuotesPostRequest
-      type: object
-      properties:
-        fspId:
-          $ref: '#/components/schemas/FspId'
-        quotesPostRequest:
-          $ref: '#/components/schemas/QuotesPostRequest'
-      required:
-        - fspId
-        - quotesPostRequest
-    quotesPostResponse:
-      title: QuotesPostResponse
-      type: object
-      properties:
-        quotes:
-          title: QuotesIDPutResponse
-          type: object
-          description: 'The object sent in the PUT /quotes/{ID} callback.'
-          properties:
-            transferAmount:
-              $ref: '#/components/schemas/Money'
-            payeeReceiveAmount:
-              $ref: '#/components/schemas/Money'
-            payeeFspFee:
-              $ref: '#/components/schemas/Money'
-            payeeFspCommission:
-              $ref: '#/components/schemas/Money'
-            expiration:
-              type: string
-              description: >-
-                Date and time until when the quotation is valid and can be
-                honored when used in the subsequent transaction.
-              example: '2016-05-24T08:38:08.699-04:00'
-            geoCode:
-              $ref: '#/components/schemas/GeoCode'
-            ilpPacket:
-              $ref: '#/components/schemas/IlpPacket'
-            condition:
-              $ref: '#/components/schemas/IlpCondition'
-            extensionList:
-              $ref: '#/components/schemas/ExtensionList'
-          required:
-            - transferAmount
-            - expiration
-            - ilpPacket
-            - condition
-        currentState:
-          $ref: '#/components/schemas/async2SyncCurrentState'
-      required:
-        - quotes
-        - currentState
-    errorQuotesResponse:
-      allOf:
-        - $ref: '#/components/schemas/errorResponse'
-        - type: object
     TransfersPostRequest:
       title: TransfersPostRequest
       type: object
@@ -2206,7 +2455,14 @@ components:
       type: object
       properties:
         transfer:
-          $ref: '#/components/schemas/TransfersIDPutResponse'
+          properties:
+            body:
+              $ref: '#/components/schemas/TransfersIDPutResponse'
+            headers:
+              type: object
+          required:
+            - body
+            - headers
         currentState:
           $ref: '#/components/schemas/async2SyncCurrentState'
       required:
@@ -2216,262 +2472,69 @@ components:
       allOf:
         - $ref: '#/components/schemas/errorResponse'
         - type: object
-    AuthorizationChannelType:
-      title: AuthorizationChannelType
-      type: string
-      enum:
-        - OTP
-        - QRCODE
-        - U2F
-      description: >
-        Below are the allowed values for the enumeration
-        AuthorizationChannelType.
-
-        - OTP - One-time password generated by the Payer FSP.
-
-        - QRCODE - QR code used as One Time Password.
-
-        - U2F - U2F is a new addition isolated to Thirdparty stream.
-
-
-        This is based on FSPIOP `AuthenticationType` with U2F added.
-      example: U2F
-    Integer:
-      title: Integer
-      type: string
-      pattern: '^[1-9]\d*$'
-      description: >-
-        The API data type Integer is a JSON String consisting of digits only.
-        Negative numbers and leading zeroes are not allowed. The data type is
-        always limited to a specific number of digits.
-    AuthorizationsPostRequest:
-      title: AuthorizationsPostRequest
-      description: POST /authorizations request object.
+    transferRequest:
       type: object
-      properties:
-        authenticationType:
-          $ref: '#/components/schemas/AuthorizationChannelType'
-        retriesLeft:
-          $ref: '#/components/schemas/Integer'
-        amount:
-          $ref: '#/components/schemas/Money'
-        transactionId:
-          $ref: '#/components/schemas/CorrelationId'
-        transactionRequestId:
-          $ref: '#/components/schemas/CorrelationId'
-        quote:
-          $ref: '#/components/schemas/QuotesIDPutResponse'
       required:
-        - authenticationType
-        - retriesLeft
+        - homeTransactionId
+        - from
+        - to
+        - amountType
+        - currency
         - amount
-        - transactionId
-        - transactionRequestId
-        - quote
-      additionalProperties: false
-    authorizationsPostRequest:
-      title: AuthorizationsPostRequest
-      description: POST /authorizations Request object
-      type: object
+        - transactionType
       properties:
-        fspId:
-          $ref: '#/components/schemas/FspId'
-        authorizationsPostRequest:
-          $ref: '#/components/schemas/AuthorizationsPostRequest'
-      required:
-        - fspId
-        - authorizationsPostRequest
-    OtpValue:
-      title: OtpValue
-      type: string
-      pattern: '^\d{3,10}$'
-      description: >-
-        The API data type OtpValue is a JSON String of 3 to 10 characters,
-        consisting of digits only. Negative numbers are not allowed. One or more
-        leading zeros are allowed.
-    QRCODE:
-      title: QRCODE
-      type: string
-      minLength: 1
-      maxLength: 64
-      description: QR code used as a One Time Password.
-    U2FPIN:
-      title: U2FPIN
-      type: string
-      pattern: '^\S{1,64}$'
-      minLength: 1
-      maxLength: 64
-      description: >
-        U2F challenge-response, where payer FSP verifies if the response
-        provided by end-user device matches the previously registered key.
-    U2FPinValue:
-      title: U2FPinValue
-      type: object
-      description: >
-        U2F challenge-response, where payer FSP verifies if the response
-        provided by end-user device matches the previously registered key.
-      properties:
-        pinValue:
-          allOf:
-            - $ref: '#/components/schemas/U2FPIN'
-          description: U2F challenge-response.
-        counter:
-          allOf:
-            - $ref: '#/components/schemas/Integer'
+        homeTransactionId:
+          type: string
           description: >-
-            Sequential counter used for cloning detection. Present only for U2F
-            authentication.
-      required:
-        - pinValue
-        - counter
-    AuthenticationValue:
-      title: AuthenticationValue
-      anyOf:
-        - $ref: '#/components/schemas/OtpValue'
-        - $ref: '#/components/schemas/QRCODE'
-        - $ref: '#/components/schemas/U2FPinValue'
-      pattern: '^\d{3,10}$|^\S{1,64}$'
-      description: >-
-        Contains the authentication value. The format depends on the
-        authentication type used in the AuthenticationInfo complex type.
-    AuthenticationInfo:
-      title: AuthenticationInfo
+            Transaction ID from the DFSP backend, used to reconcile transactions
+            between the Switch and DFSP backend systems.
+        from:
+          $ref: '#/components/schemas/transferParty'
+        to:
+          $ref: '#/components/schemas/transferParty'
+        amountType:
+          $ref: '#/components/schemas/AmountType'
+        currency:
+          $ref: '#/components/schemas/Currency'
+        amount:
+          $ref: '#/components/schemas/Amount'
+        transactionType:
+          $ref: '#/components/schemas/transferTransactionType'
+        subScenario:
+          $ref: '#/components/schemas/TransactionSubScenario'
+        note:
+          $ref: '#/components/schemas/Note'
+        quoteRequestExtensions:
+          $ref: '#/components/schemas/extensionListEmptiable'
+        transferRequestExtensions:
+          $ref: '#/components/schemas/extensionListEmptiable'
+        skipPartyLookup:
+          description: >-
+            Set to true if supplying an FSPID for the payee party and no party
+            resolution is needed. This may be useful is a previous party
+            resolution has been performed.
+          type: boolean
+    transferStatusResponse:
       type: object
-      description: Data model for the complex type AuthenticationInfo.
-      properties:
-        authentication:
-          $ref: '#/components/schemas/AuthenticationType'
-        authenticationValue:
-          $ref: '#/components/schemas/AuthenticationValue'
       required:
-        - authentication
-        - authenticationValue
-    AuthorizationResponseType:
-      title: AuthorizationResponseType
-      description: |
-        Enum containing response information; if the customer entered the
-        authentication value, rejected the transaction, or requested a
-        resend of the authentication value.
-      type: string
-      enum:
-        - ENTERED
-        - REJECTED
-        - RESEND
-    authorizationsPostResponse:
-      title: AuthorizationsPostResponse
-      description: POST /authorizations response object
-      type: object
-      properties:
-        authorizations:
-          type: object
-          properties:
-            authenticationInfo:
-              $ref: '#/components/schemas/AuthenticationInfo'
-            responseType:
-              $ref: '#/components/schemas/AuthorizationResponseType'
-          required:
-            - responseType
-        currentState:
-          $ref: '#/components/schemas/async2SyncCurrentState'
-      required:
-        - authorizations
+        - transferId
         - currentState
-      additionalProperties: false
-    errorAuthorizationsResponse:
-      allOf:
-        - $ref: '#/components/schemas/errorResponse'
-        - type: object
+        - fulfil
+      properties:
+        transferId:
+          $ref: '#/components/schemas/CorrelationId'
+        currentState:
+          $ref: '#/components/schemas/transferStatus'
+        fulfil:
+          type: object
+          required:
+            - body
+          properties:
+            body:
+              $ref: '#/components/schemas/TransfersIDPutResponse'
+            headers:
+              type: object
   responses:
-    transferSuccess:
-      description: Transfer completed successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/transferResponse'
-    transferBadRequest:
-      description: 'Malformed or missing required body, headers or parameters'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/errorTransferResponse'
-    transferServerError:
-      description: An error occurred processing the transfer
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/errorTransferResponse'
-    transferTimeout:
-      description: Timeout occurred processing the transfer
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/errorTransferResponse'
-    bulkTransferSuccess:
-      description: Bulk transfer completed successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/bulkTransferResponse'
-    bulkTransferBadRequest:
-      description: 'Malformed or missing required body, headers or parameters'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/bulkTransferErrorResponse'
-    bulkTransferServerError:
-      description: An error occurred processing the bulk transfer
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/bulkTransferErrorResponse'
-    bulkTransferTimeout:
-      description: Timeout occurred processing the bulk transfer
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/bulkTransferErrorResponse'
-    bulkQuoteSuccess:
-      description: Bulk quote completed successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/bulkQuoteResponse'
-    bulkQuoteBadRequest:
-      description: 'Malformed or missing required body, headers or parameters'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/bulkQuoteErrorResponse'
-    bulkQuoteServerError:
-      description: An error occurred processing the bulk quote
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/bulkQuoteErrorResponse'
-    bulkQuoteTimeout:
-      description: Timeout occurred processing the bulk quote
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/bulkQuoteErrorResponse'
-    requestToPaySuccess:
-      description: Request to Pay completed successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/requestToPayResponse'
-    requestToPayTransferSuccess:
-      description: Transfer completed successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/requestToPayTransferResponse'
-    requestToPayTransferBadRequest:
-      description: 'Malformed or missing required body, headers or parameters'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/errorTransferResponse'
     accountsCreationCompleted:
       description: Accounts creation completed
       content:
@@ -2490,6 +2553,58 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/errorAccountsResponse'
+    bulkQuoteSuccess:
+      description: Bulk quote completed successfully
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/bulkQuoteResponse'
+    bulkQuoteBadRequest:
+      description: Malformed or missing required body, headers or parameters
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/bulkQuoteErrorResponse'
+    bulkQuoteServerError:
+      description: An error occurred processing the bulk quote
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/bulkQuoteErrorResponse'
+    bulkQuoteTimeout:
+      description: Timeout occurred processing the bulk quote
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/bulkQuoteErrorResponse'
+    bulkTransactionAccepted:
+      description: Bulk transfer accepted successfully
+    bulkTransferBadRequest:
+      description: Malformed or missing required body, headers or parameters
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/bulkTransferErrorResponse'
+    errorResponse:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/errorResponse'
+    bulkTransactionPutBadRequest:
+      description: Malformed or missing required body, headers or parameters
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/bulkTransactionAcceptPartyErrorResponse'
+              - $ref: '#/components/schemas/bulkTransactionAcceptQuoteErrorResponse'
+    bulkTransferSuccess:
+      description: Bulk transfer completed successfully
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/bulkTransferResponse'
     partiesByIdSuccess:
       description: PartiesByIdSuccess
       content:
@@ -2517,6 +2632,42 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/errorQuotesResponse'
+    requestToPaySuccess:
+      description: Request to Pay completed successfully
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/requestToPayResponse'
+    transferServerError:
+      description: An error occurred processing the transfer
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/errorTransferResponse'
+    transferTimeout:
+      description: Timeout occurred processing the transfer
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/errorTransferResponse'
+    requestToPayTransferSuccess:
+      description: Transfer completed successfully
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/requestToPayTransferResponse'
+    requestToPayTransferBadRequest:
+      description: Malformed or missing required body, headers or parameters
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/errorTransferResponse'
+    transferSuccess:
+      description: Transfer completed successfully
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/transferResponse'
     simpleTransfersPostSuccess:
       description: sync response from POST /simpleTransfers
       content:
@@ -2529,37 +2680,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/errorSimpleTransfersResponse'
-    authorizationPostSuccess:
-      description: Sync response from POST /authorizations
+    transferBadRequest:
+      description: Malformed or missing required body, headers or parameters
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/authorizationsPostResponse'
-    authorizationsServerError:
-      description: An error occurred processing the authorizations request
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/errorAuthorizationsResponse'
+            $ref: '#/components/schemas/errorTransferResponse'
   parameters:
-    transferId:
-      name: transferId
-      in: path
-      required: true
-      schema:
-        $ref: '#/components/schemas/CorrelationId'
-      description: >-
-        Identifier of the transfer to continue as returned in the response to a
-        `POST /transfers` request.
-    bulkTransferId:
-      name: bulkTransferId
-      in: path
-      required: true
-      schema:
-        $ref: '#/components/schemas/CorrelationId'
-      description: >-
-        Identifier of the bulk transfer to continue as returned in the response
-        to a `POST /bulkTransfers` request.
     bulkQuoteId:
       name: bulkQuoteId
       in: path
@@ -2569,22 +2696,31 @@ components:
       description: >-
         Identifier of the bulk transfer to continue as returned in the response
         to a `POST /bulkTransfers` request.
-    requestToPayTransactionId:
-      name: requestToPayTransactionId
+    bulkTransactionId:
+      name: bulkTransactionId
       in: path
       required: true
       schema:
         $ref: '#/components/schemas/CorrelationId'
       description: >-
-        Identifier of the merchant request to pay transfer to continue as
-        returned in the response to a `POST /requestToPayTransfer` request.
+        Identifier of the bulk transaction to continue as returned in the
+        response to a `POST /bulkTransaction` request.
+    bulkTransferId:
+      name: bulkTransferId
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/CorrelationId'
+      description: >-
+        Identifier of the bulk transfer to continue as returned in the response
+        to a `POST /bulkTransfers` request.
     Type:
       name: Type
       in: path
       required: true
       schema:
         type: string
-      description: 'The type of the party identifier. For example, `MSISDN`, `PERSONAL_ID`.'
+      description: The type of the party identifier. For example, `MSISDN`, `PERSONAL_ID`.
     ID:
       name: ID
       in: path
@@ -2601,3 +2737,30 @@ components:
       description: >-
         A sub-identifier of the party identifier, or a sub-type of the party
         identifier's type. For example, `PASSPORT`, `DRIVING_LICENSE`.
+    requestToPayId:
+      name: requestToPayId
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/CorrelationId'
+      description: >-
+        Identifier of the merchant request to pay to continue as returned in the
+        response to a `POST /requestToPay` request.
+    requestToPayTransactionId:
+      name: requestToPayTransactionId
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/CorrelationId'
+      description: >-
+        Identifier of the merchant request to pay transfer to continue as
+        returned in the response to a `POST /requestToPayTransfer` request.
+    transferId:
+      name: transferId
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/CorrelationId'
+      description: >-
+        Identifier of the transfer to continue as returned in the response to a
+        `POST /transfers` request.

--- a/modules/api-svc/package.json
+++ b/modules/api-svc/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@koa/cors": "^4.0.0",
-    "@mojaloop/api-snippets": "17.0.4",
+    "@mojaloop/api-snippets": "17.0.5-snapshot.0",
     "@mojaloop/central-services-error-handling": "^12.0.5",
     "@mojaloop/central-services-logger": "^11.2.0",
     "@mojaloop/central-services-metrics": "^12.0.5",

--- a/modules/api-svc/package.json
+++ b/modules/api-svc/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@koa/cors": "^4.0.0",
-    "@mojaloop/api-snippets": "17.0.5-snapshot.0",
+    "@mojaloop/api-snippets": "17.0.5-snapshot.1",
     "@mojaloop/central-services-error-handling": "^12.0.5",
     "@mojaloop/central-services-logger": "^11.2.0",
     "@mojaloop/central-services-metrics": "^12.0.5",

--- a/modules/api-svc/src/InboundServer/handlers.js
+++ b/modules/api-svc/src/InboundServer/handlers.js
@@ -540,7 +540,7 @@ const getQuoteById = async (ctx) => {
 };
 
 /**
- * Handles a PUT /quotes/{ID}. This is a response to a POST /quotes request
+ * Handles a PUT /transactionRequests/{ID}. This is a response to a POST /transactionRequests request
  */
 const putTransactionRequestsById = async (ctx) => {
     // publish an event onto the cache for subscribers to action
@@ -551,6 +551,24 @@ const putTransactionRequestsById = async (ctx) => {
     };
     await ctx.state.cache.publish(`txnreq_${transactionRequestId}`, {
         type: 'transactionRequestResponse',
+        data
+    });
+
+    ctx.response.status = ReturnCodes.OK.CODE;
+};
+
+/**
+ * Handles a PUT /transactionRequests/{ID}/error. This is a response to a POST /transactionRequests request
+ */
+const putTransactionRequestsByIdError = async (ctx) => {
+    // publish an event onto the cache for subscribers to action
+    const transactionRequestId = ctx.state.path.params.ID;
+    const data = {
+        body: { ...ctx.request.body },
+        headers: { ...ctx.request.headers }
+    };
+    await ctx.state.cache.publish(`txnreq_${transactionRequestId}`, {
+        type: 'transactionRequestResponseError',
         data
     });
 
@@ -979,5 +997,8 @@ module.exports = {
     },
     '/transactionRequests/{ID}': {
         put: putTransactionRequestsById
+    },
+    '/transactionRequests/{ID}/error': {
+        put: putTransactionRequestsByIdError
     }
 };

--- a/modules/api-svc/src/OutboundServer/handlers.js
+++ b/modules/api-svc/src/OutboundServer/handlers.js
@@ -502,6 +502,41 @@ const postRequestToPay = async (ctx) => {
     }
 };
 
+/**
+ * Handler for resuming outbound requestToPay in scenarios where two-step transfers are enabled
+ * by disabling the autoAcceptParty SDK option
+ */
+const putRequestToPay = async (ctx) => {
+    try {
+        // this requires a multi-stage sequence with the switch.
+        // use the transfers model to execute asynchronous stages with the switch
+        const model = new OutboundRequestToPayModel({
+            ...ctx.state.conf,
+            cache: ctx.state.cache,
+            logger: ctx.state.logger,
+            wso2: ctx.state.wso2,
+        });
+
+        // TODO: check the incoming body to reject party or quote when requested to do so
+        const data = ctx.request.body;
+        // load the transfer model from cache and start it running again
+        await model.load(ctx.state.path.params.requestToPayId);
+        let response;
+        if(data.acceptParty === true) {
+            response = await model.run();
+        } else {
+            response = await model.rejectRequestToPay();
+        }
+
+        // return the result
+        ctx.response.status = ReturnCodes.OK.CODE;
+        ctx.response.body = response;
+    }
+    catch(err) {
+        return handleTransferError('putRequestToPay', err, ctx);
+    }
+};
+
 const healthCheck = async (ctx) => {
     ctx.response.status = ReturnCodes.OK.CODE;
     ctx.response.body = '';
@@ -636,6 +671,9 @@ module.exports = {
     },
     '/requestToPay': {
         post: postRequestToPay
+    },
+    '/requestToPay/{requestToPayId}': {
+        put: putRequestToPay
     },
     '/requestToPayTransfer': {
         post: postRequestToPayTransfer

--- a/yarn.lock
+++ b/yarn.lock
@@ -2351,6 +2351,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mojaloop/api-snippets@npm:17.0.5-snapshot.0":
+  version: 17.0.5-snapshot.0
+  resolution: "@mojaloop/api-snippets@npm:17.0.5-snapshot.0"
+  dependencies:
+    "@apidevtools/json-schema-ref-parser": ^9.1.2
+    commander: ^10.0.1
+    jest-ts-auto-mock: ^2.1.0
+    js-yaml: ^4.1.0
+    json-refs: ^3.0.15
+    openapi-types: ^12.1.0
+    openapi-typescript: ^5.4.1
+    ts-auto-mock: ^3.6.4
+    ttypescript: ^1.5.15
+  checksum: b10ee234bcd55f8d8f2c15df0e5e28fcc85f9339814d1f703207cf3e727b4703108e858a0ccf2e55e3a889c74792131a91e7cf9ad4861ada85550ba1f1c37a15
+  languageName: node
+  linkType: hard
+
 "@mojaloop/central-services-error-handling@npm:^12.0.5":
   version: 12.0.5
   resolution: "@mojaloop/central-services-error-handling@npm:12.0.5"
@@ -2534,7 +2551,7 @@ __metadata:
     "@babel/core": ^7.21.4
     "@babel/preset-env": ^7.21.4
     "@koa/cors": ^4.0.0
-    "@mojaloop/api-snippets": 17.0.4
+    "@mojaloop/api-snippets": 17.0.5-snapshot.0
     "@mojaloop/central-services-error-handling": ^12.0.5
     "@mojaloop/central-services-logger": ^11.2.0
     "@mojaloop/central-services-metrics": ^12.0.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -2351,9 +2351,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mojaloop/api-snippets@npm:17.0.5-snapshot.0":
-  version: 17.0.5-snapshot.0
-  resolution: "@mojaloop/api-snippets@npm:17.0.5-snapshot.0"
+"@mojaloop/api-snippets@npm:17.0.5-snapshot.1":
+  version: 17.0.5-snapshot.1
+  resolution: "@mojaloop/api-snippets@npm:17.0.5-snapshot.1"
   dependencies:
     "@apidevtools/json-schema-ref-parser": ^9.1.2
     commander: ^10.0.1
@@ -2364,7 +2364,7 @@ __metadata:
     openapi-typescript: ^5.4.1
     ts-auto-mock: ^3.6.4
     ttypescript: ^1.5.15
-  checksum: b10ee234bcd55f8d8f2c15df0e5e28fcc85f9339814d1f703207cf3e727b4703108e858a0ccf2e55e3a889c74792131a91e7cf9ad4861ada85550ba1f1c37a15
+  checksum: 25d0efc501454465127914f8b032a176c4c7388cf7c9ce457d62984d3652e519b06d2f5edd007b887754e30a3d349c33ba70a4b2681a956a9c9a69a263ccb4c8
   languageName: node
   linkType: hard
 
@@ -2551,7 +2551,7 @@ __metadata:
     "@babel/core": ^7.21.4
     "@babel/preset-env": ^7.21.4
     "@koa/cors": ^4.0.0
-    "@mojaloop/api-snippets": 17.0.5-snapshot.0
+    "@mojaloop/api-snippets": 17.0.5-snapshot.1
     "@mojaloop/central-services-error-handling": ^12.0.5
     "@mojaloop/central-services-logger": ^11.2.0
     "@mojaloop/central-services-metrics": ^12.0.5


### PR DESCRIPTION
fix: put transactionrequest and put transactionrequest error handlers

Fixes:
- Add support for missing PUT /transactionRequests/{transactionId}/error callback handling (https://github.com/mojaloop/project/issues/3322)
- RTP on SDK’s payer side requires AUTO_ACCEPT_PARTY=true to complete (https://github.com/mojaloop/project/issues/3321)
