### PR TITLE
feat: allow optional dfspId to be in the endpoint path

### DIFF
--- a/modules/api-svc/src/InboundServer/handlers.js
+++ b/modules/api-svc/src/InboundServer/handlers.js
@@ -36,6 +36,10 @@ const extractBodyHeadersSourceFspId = ctx => ({
  */
 const createInboundTransfersModel = (ctx) => new InboundTransfersModel({
     ...ctx.state.conf,
+    ...ctx.state.path?.params?.dfspId && {
+        dfspId: ctx.state.path.params.dfspId,
+        backendEndpoint: `${ctx.state.conf.backendEndpoint}/${ctx.state.path.params.dfspId}`
+    },
     cache: ctx.state.cache,
     logger: ctx.state.logger,
     wso2: ctx.state.wso2,

--- a/modules/api-svc/src/OutboundServer/index.js
+++ b/modules/api-svc/src/OutboundServer/index.js
@@ -32,7 +32,6 @@ const apiSpecs = yaml.load(fs.readFileSync(specPath));
 const endpointRegex = /\/.*/g;
 const logExcludePaths = ['/'];
 const _validator = new Validate({ logExcludePaths });
-const _initialize = _validator.initialise(apiSpecs);
 
 class OutboundApi extends EventEmitter {
     constructor(conf, logger, cache, validator, metricsClient, wso2, eventProducer, eventLogger) {
@@ -42,6 +41,7 @@ class OutboundApi extends EventEmitter {
         this._conf = conf;
         this._cache = cache;
         this._metricsClient = metricsClient;
+        this._initialize = _validator.initialise(apiSpecs, conf);
 
         this._api.use(middlewares.createErrorHandler(this._logger));
         this._api.use(middlewares.createRequestIdGenerator(this._logger));
@@ -74,13 +74,7 @@ class OutboundApi extends EventEmitter {
         }
 
         this._api.use(middlewares.createRequestValidator(validator));
-        function mount(routes) {
-            if (!conf.multiDfsp) return routes;
-            return Object.fromEntries(Object.entries(routes).map(([path, route]) => {
-                return [`/{dfspId}${path}`, route];
-            }));
-        }
-        this._api.use(router(mount(handlers)));
+        this._api.use(router(handlers, conf));
 
         this._api.use(middlewares.createResponseLogging(this._logger));
     }
@@ -124,7 +118,7 @@ class OutboundServer extends EventEmitter {
     async start() {
         const { port } = this._conf.outbound;
         await this._eventProducer?.init();
-        await _initialize;
+        await this._initialize;
         await this._api.start();
         await new Promise((resolve) => this._server.listen(port, resolve));
         this._logger.isInfoEnabled && this._logger.info(`Serving outbound API on port ${this._conf.outbound.port}`);

--- a/modules/api-svc/src/index.js
+++ b/modules/api-svc/src/index.js
@@ -125,6 +125,7 @@ class Server extends EventEmitter {
 
         if (this.conf.enableTestFeatures) {
             this.testServer = new TestServer({
+                config: this.conf,
                 port: this.conf.test.port,
                 logger: this.logger.push(LOG_ID.TEST),
                 cache: this.cache,

--- a/modules/api-svc/src/lib/router.js
+++ b/modules/api-svc/src/lib/router.js
@@ -36,4 +36,4 @@ module.exports = (routes, config) => {
     return router(Object.fromEntries(Object.entries(routes).map(([path, route]) => {
         return [`/{dfspId}${path}`, route];
     })));
-}
+};

--- a/modules/api-svc/src/lib/router.js
+++ b/modules/api-svc/src/lib/router.js
@@ -13,7 +13,7 @@
 const { Enum } = require('@mojaloop/central-services-shared');
 const { ReturnCodes } = Enum.Http;
 
-module.exports = (handlerMap) => async (ctx, next) => {
+const router = (handlerMap) => async (ctx, next) => {
     const handlers = handlerMap[ctx.state.path.pattern];
     const handler = handlers ? handlers[ctx.method.toLowerCase()] : undefined;
     if (!handlers || !handler) {
@@ -30,3 +30,10 @@ module.exports = (handlerMap) => async (ctx, next) => {
     }
     await next();
 };
+
+module.exports = (routes, config) => {
+    if (!config?.multiDfsp) return router(routes);
+    return router(Object.fromEntries(Object.entries(routes).map(([path, route]) => {
+        return [`/{dfspId}${path}`, route];
+    })));
+}

--- a/modules/api-svc/src/lib/validate.js
+++ b/modules/api-svc/src/lib/validate.js
@@ -89,14 +89,14 @@ const extractBody = rqBody => {
 //     }
 //   }
 // }
-const transformApiDoc = apiDoc => ({
+const transformApiDoc = (apiDoc, conf) => ({
     ...apiDoc,
     // TODO: as we now discard most of the extra information, it probably makes sense to explicitly
     // return the object form we're interested in, rather than do all of this awkward object
     // mapping. I.e.:
     // return { get: { validator: [Function validator] }, put: { validator: [Function validator] } };
     paths: Object.assign(...Object.entries(apiDoc.paths).map(([pathName, pathValue]) => ({
-        [pathName]: Object.assign(
+        [conf?.multiDfsp ? `/{dfspId}${pathName}` : pathName]: Object.assign(
             ...Object.entries(pathValue)
                 .filter(([method,]) => httpMethods.includes(method))
                 .map(([method, methodValue]) => {
@@ -135,12 +135,12 @@ class Validator {
     // apiDoc
     //   POJO representing apiDoc API spec. Example:
     //   const v = new Validator(require('./apiDoc.json'));
-    async initialise(apiDoc) {
+    async initialise(apiDoc, conf) {
         // Dereferencing the api doc makes it much easier to work with. Specifically, it allows us
         // to compile a validator for each path.
         const pojoApiDoc = await jsrp.dereference(apiDoc);
 
-        this.apiDoc = transformApiDoc(pojoApiDoc);
+        this.apiDoc = transformApiDoc(pojoApiDoc, conf);
         const pathParamMatch = /\{[^{}]+\}/g;
         this.paths = Object.entries(this.apiDoc.paths).map(([path, pathSpec]) => ({
             pattern: path,


### PR DESCRIPTION
By setting the env variable MULTI_DFSP=true, we can handle multiple DFSPs with a single server. This saves resources when running multiple DFSPs and allows much bigger number of DFSPs to be handled without the need of extra configuration.