### PR TITLE
chore: update orb to v1.1.17 and clean up grype config (#4044)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  build: mojaloop/build@1.1.16
+  build: mojaloop/build@1.1.17
 workflows:
   setup:
     jobs:

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,5 +1,3 @@
-scan-type: source
-
 ignore:
   - vulnerability: CVE-2025-3277
   - vulnerability: CVE-2024-9410


### PR DESCRIPTION
## Summary
- Updates `mojaloop/build` orb from v1.1.16 to v1.1.17 (latest)
- Removes redundant `scan-type: source` from `.grype.yaml` (source scanning is now the default in the orb)

## Context
This repo is one of four that create git tags on release but do not create corresponding GitHub Releases. The orb update ensures the CI pipeline uses the latest version with all available fixes, and the grype config cleanup removes a now-unnecessary setting.

**Note:** The root cause of missing GitHub releases may also involve CircleCI context/token permissions — this should be verified by checking the pipeline logs for recent release runs to see if the `GitHub release` job ran and what error it produced.

Refs: https://github.com/mojaloop/project/issues/4044

## Test plan
- [ ] Verify CircleCI pipeline runs successfully on this branch
- [ ] After merge, monitor next release pipeline to confirm `GitHub release` job executes
- [ ] Check CircleCI pipeline logs if `GitHub release` job still fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)